### PR TITLE
Mhp23 patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ A high-performance [TensorFlow Lite](https://www.tensorflow.org/lite) library fo
     ```
     This allows you to drop `.tflite` files into your app and swap them out at runtime without having to rebuild anything! 🔥
 3. (Optional) If you want to enable the GPU Delegate, see ["Using GPU Delegates"](#using-gpu-delegates) down below.
-4. Run your app (`yarn android` / `npx pod-install && yarn ios`)
+4. Run your app:
+   - For Android: `yarn android`
+   - For iOS:
+       - If you're using Apple silicon (M1, M2, or M3), Since the current stable version of TensorFlow Lite doesn't support the `arm64` simulators, you'll need to use the following command to run the app on `x86_64` architecture: `npx pod-install && yarn ios --destination arch=x86_64`
+       - Otherwise, use this command: `npx pod-install && yarn ios`
 
 ## Usage
 

--- a/react-native-fast-tflite.podspec
+++ b/react-native-fast-tflite.podspec
@@ -23,6 +23,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm}", "cpp/**/*.{hpp,cpp,c,h}"
 
   s.pod_target_xcconfig = {
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64 i386',
     'GCC_PREPROCESSOR_DEFINITIONS' => "$(inherited) FAST_TFLITE_ENABLE_CORE_ML=#{enableCoreMLDelegate}",
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
   }


### PR DESCRIPTION
- Excluded `arm64` simulators from the pod
- Updating docs to run app on iOS simulators

Since the current stable version of TensorFlow Lite doesn't support `arm64` simulators, building the app is failing for Apple Silicon (It appears that this issue is resolved in the TensorFlow Lite nightly version). Therefore, in this PR, the arm64 simulator is excluded, and instructions for running the app directly on `x86_64` architecture simulators from the command line are added to the documentation.