### PR TITLE
feat: Use native `TensorFlowLiteC` library from source

### DIFF
--- a/scripts/build-tensorflow-android.sh
+++ b/scripts/build-tensorflow-android.sh
@@ -16,16 +16,11 @@ then
   # Assumes the user ran ./configure in tensorflow/ already
   cd tensorflow
 
-  bazel build --config=ios_fat -c opt --cxxopt=--std=c++17 //tensorflow/lite/ios:TensorFlowLiteC_framework
-  bazel build --config=ios_fat -c opt --cxxopt=--std=c++17 //tensorflow/lite/ios:TensorFlowLiteCCoreML_framework
+  bazel build --config=android # -c opt --cxxopt=--std=c++17 //tensorflow/lite/ios:TensorFlowLiteC_framework
 
   cd ..
 
-  cp -f -r tensorflow/bazel-bin/tensorflow/lite/ios/ ios/
+  cp -f -r tensorflow/bazel-bin/tensorflow/lite/android/ android/
 
-  unzip -o ios/TensorFlowLiteC_framework.zip -d ios
-  rm ios/TensorFlowLiteC_framework.zip
-
-  unzip -o ios/TensorFlowLiteCCoreML_framework.zip -d ios
-  rm ios/TensorFlowLiteCCoreML_framework.zip
+  echo "What now?"
 fi


### PR DESCRIPTION
Uses the native TensorFlowLiteC library from source, (here: `tensorflow/` git submodule) to avoid using different versions for Android and iOS.

```
ERROR: /private/var/tmp/_bazel_mrousavy/10ea0aaf7e74747e617bc9430c3edeaf/external/ruy/ruy/BUILD:423:11: Compiling ruy/denormal.cc failed: undeclared inclusion(s) in rule '@ruy//ruy:denormal':
this rule is missing dependency declarations for the following files included by 'ruy/denormal.cc':
  'external/androidndk/toolchains/llvm/prebuilt/darwin-x86_64/lib/clang/17/include/stdint.h'
  'external/androidndk/toolchains/llvm/prebuilt/darwin-x86_64/lib/clang/17/include/stddef.h'
  'external/androidndk/toolchains/llvm/prebuilt/darwin-x86_64/lib/clang/17/include/__stddef_max_align_t.h'
Target //tensorflow/lite:tensorflowlite failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.481s, Critical Path: 0.13s
INFO: 11 processes: 11 internal.
FAILED: Build did NOT complete successfully
```

So far, I couldn't manage to get Android to build with bazel yet. idk @thomas-coldwell do you have any ideas?