### PR TITLE
Add GPU support for Android

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ We follow the [conventional commits specification](https://www.conventionalcommi
 - `fix`: bug fixes, e.g. fix crash due to deprecated method.
 - `feat`: new features, e.g. add new method to the module.
 - `refactor`: code refactor, e.g. migrate from class components to hooks.
-- `docs`: changes into documentation, e.g. add usage example for the module..
+- `docs`: changes into documentation, e.g. add usage example for the module.
 - `test`: adding or updating tests, e.g. add integration tests using detox.
 - `chore`: tooling changes, e.g. change CI config.
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,34 @@ If you are on bare React Native, you need to include the CoreML/Metal code in yo
 > [!NOTE]
 > Since some operations aren't supported on the CoreML delegate, make sure your Model is able to use the CoreML GPU delegate.
 
+#### Android GPU/NNAPI (Android)
+
+To enable GPU or NNAPI delegate in Android, you **may** need to include `OpenCL` library with `uses-native-library` on `application` scope in AndroidManifest.xml, starting from Android 12.
+
+```xml
+<!-- Like this -->
+<uses-native-library android:name="libOpenCL.so" android:required="false" />
+
+<!-- You may need one/all of the followings depends on your targeting devices -->
+<uses-native-library android:name="libOpenCL-pixel.so" android:required="false" />
+<uses-native-library android:name="libGLES_mali.so" android:required="false" />
+<uses-native-library android:name="libPVROCL.so" android:required="false" />
+```
+
+Then, you can just use it:
+```ts
+const model = await loadTensorflowModel(require('assets/my-model.tflite'), 'android-gpu')
+// or
+const model = await loadTensorflowModel(require('assets/my-model.tflite'), 'nnapi')
+```
+
+> [!WARNING]
+> NNAPI is deprecated on Android 15. Hence, it is not recommended in future projects.
+> Both has similiar performance, but GPU delegate has better initial loading time.
+
+> [!NOTE]
+> Android does not provide support for OpenCL officially, however, most gpu vendors do provide support for it.
+
 ## Community Discord
 
 [Join the Margelo Community Discord](https://discord.gg/6CSHz2qAvA) to chat about react-native-fast-tflite or other Margelo libraries.

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -9,11 +9,19 @@ find_package(ReactAndroid REQUIRED CONFIG)
 find_package(fbjni REQUIRED CONFIG)
 
 find_library(
-        TFLITE
-        tensorflowlite_jni
-        PATHS "./src/main/cpp/lib/tensorflow/jni/${ANDROID_ABI}"
-        NO_DEFAULT_PATH
-        NO_CMAKE_FIND_ROOT_PATH
+  TFLITE
+  tensorflowlite_jni
+  PATHS "./src/main/cpp/lib/tensorflow/jni/${ANDROID_ABI}"
+  NO_DEFAULT_PATH
+  NO_CMAKE_FIND_ROOT_PATH
+)
+
+find_library(
+  TFLITE_GPU
+  tensorflowlite_gpu_jni
+  PATHS "./src/main/cpp/lib/tensorflow/jni/${ANDROID_ABI}"
+  NO_DEFAULT_PATH
+  NO_CMAKE_FIND_ROOT_PATH
 )
 
 string(APPEND CMAKE_CXX_FLAGS " -DANDROID")
@@ -49,4 +57,5 @@ target_link_libraries(
   ReactAndroid::reactnativejni    # <-- CallInvokerImpl
   fbjni::fbjni                    # <-- fbjni.h
   ${TFLITE}
+  ${TFLITE_GPU}
 )

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -126,6 +126,11 @@ dependencies {
   implementation "org.tensorflow:tensorflow-lite:2.12.0"
   extractHeaders("org.tensorflow:tensorflow-lite:2.12.0")
   extractSO("org.tensorflow:tensorflow-lite:2.12.0")
+
+  // Tensorflow Lite GPU delegate
+  implementation "org.tensorflow:tensorflow-lite-gpu:2.12.0"
+  extractHeaders("org.tensorflow:tensorflow-lite-gpu:2.12.0")
+  extractSO("org.tensorflow:tensorflow-lite-gpu:2.12.0")
 }
 
 task extractAARHeaders {

--- a/cpp/TensorflowPlugin.cpp
+++ b/cpp/TensorflowPlugin.cpp
@@ -67,58 +67,57 @@ void TensorflowPlugin::installToRuntime(jsi::Runtime& runtime,
           }
         }
 
-        auto promise =
-            Promise::createPromise(runtime, [=, &runtime](std::shared_ptr<Promise> promise) {
-              // Launch async thread
-              std::async(std::launch::async, [=, &runtime]() {
-                try {
-                  // Fetch model from URL (JS bundle)
-                  Buffer buffer = fetchURL(modelPath);
+        auto promise = Promise::createPromise(runtime, [=, &runtime](
+                                                           std::shared_ptr<Promise> promise) {
+          // Launch async thread
+          std::async(std::launch::async, [=, &runtime]() {
+            try {
+              // Fetch model from URL (JS bundle)
+              Buffer buffer = fetchURL(modelPath);
 
-                  // Load Model into Tensorflow
-                  auto model = TfLiteModelCreate(buffer.data, buffer.size);
-                  if (model == nullptr) {
-                    callInvoker->invokeAsync([=]() {
-                      promise->reject("Failed to load model from \"" + modelPath + "\"!");
-                    });
-                    return;
-                  }
+              // Load Model into Tensorflow
+              auto model = TfLiteModelCreate(buffer.data, buffer.size);
+              if (model == nullptr) {
+                callInvoker->invokeAsync(
+                    [=]() { promise->reject("Failed to load model from \"" + modelPath + "\"!"); });
+                return;
+              }
 
-                  // Create TensorFlow Interpreter
-                  auto options = TfLiteInterpreterOptionsCreate();
+              // Create TensorFlow Interpreter
+              auto options = TfLiteInterpreterOptionsCreate();
 
-                  switch (delegateType) {
-                    case Delegate::CoreML: {
+              switch (delegateType) {
+                case Delegate::CoreML: {
 #if FAST_TFLITE_ENABLE_CORE_ML
-                      TfLiteCoreMlDelegateOptions delegateOptions;
-                      auto delegate = TfLiteCoreMlDelegateCreate(&delegateOptions);
-                      TfLiteInterpreterOptionsAddDelegate(options, delegate);
-                      break;
+                  TfLiteCoreMlDelegateOptions delegateOptions;
+                  auto delegate = TfLiteCoreMlDelegateCreate(&delegateOptions);
+                  TfLiteInterpreterOptionsAddDelegate(options, delegate);
+                  break;
 #else
                       callInvoker->invokeAsync([=]() {
                         promise->reject("CoreML Delegate is not enabled! Set $EnableCoreMLDelegate to true in Podfile and rebuild.");
                       });
                       return;
 #endif
-                    }
-                    case Delegate::Metal: {
-                      callInvoker->invokeAsync(
-                          [=]() { promise->reject("Metal Delegate is not supported!"); });
-                      return;
-                    }
+                }
+                case Delegate::Metal: {
+                  callInvoker->invokeAsync(
+                      [=]() { promise->reject("Metal Delegate is not supported!"); });
+                  return;
+                }
 #ifdef ANDROID
-                    case Delegate::NnApi: {
-                      TfLiteNnapiDelegateOptions delegateOptions = TfLiteNnapiDelegateOptionsDefault();
-                      auto delegate = TfLiteNnapiDelegateCreate(&delegateOptions);
-                      TfLiteInterpreterOptionsAddDelegate(options, delegate);
-                      break;
-                    }
-                    case Delegate::AndroidGPU: {
-                      TfLiteGpuDelegateOptionsV2 delegateOptions = TfLiteGpuDelegateOptionsV2Default();
-                      auto delegate = TfLiteGpuDelegateV2Create(&delegateOptions);
-                      TfLiteInterpreterOptionsAddDelegate(options, delegate);
-                      break;
-                    }
+                case Delegate::NnApi: {
+                  TfLiteNnapiDelegateOptions delegateOptions = TfLiteNnapiDelegateOptionsDefault();
+                  auto delegate = TfLiteNnapiDelegateCreate(&delegateOptions);
+                  TfLiteInterpreterOptionsAddDelegate(options, delegate);
+                  break;
+                }
+                case Delegate::AndroidGPU: {
+                  TfLiteGpuDelegateOptionsV2 delegateOptions = TfLiteGpuDelegateOptionsV2Default();
+                  auto delegate = TfLiteGpuDelegateV2Create(&delegateOptions);
+                  TfLiteInterpreterOptionsAddDelegate(options, delegate);
+                  break;
+                }
 #else
                     case Delegate::NnApi: {
                       callInvoker->invokeAsync([=]() { 
@@ -131,39 +130,39 @@ void TensorflowPlugin::installToRuntime(jsi::Runtime& runtime,
                       });
                     }
 #endif
-                    default: {
-                      // use default CPU delegate.
-                    }
-                  }
-
-                  auto interpreter = TfLiteInterpreterCreate(model, options);
-
-                  if (interpreter == nullptr) {
-                    callInvoker->invokeAsync([=]() {
-                      promise->reject("Failed to create TFLite interpreter from model \"" +
-                                      modelPath + "\"!");
-                    });
-                    return;
-                  }
-
-                  // Initialize Model and allocate memory buffers
-                  auto plugin = std::make_shared<TensorflowPlugin>(interpreter, buffer,
-                                                                   delegateType, callInvoker);
-
-                  callInvoker->invokeAsync([=, &runtime]() {
-                    auto result = jsi::Object::createFromHostObject(runtime, plugin);
-                    promise->resolve(std::move(result));
-                  });
-
-                  auto end = std::chrono::steady_clock::now();
-                  log("Successfully loaded Tensorflow Model in %i ms!",
-                      std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count());
-                } catch (std::exception& error) {
-                  std::string message = error.what();
-                  callInvoker->invokeAsync([=]() { promise->reject(message); });
+                default: {
+                  // use default CPU delegate.
                 }
+              }
+
+              auto interpreter = TfLiteInterpreterCreate(model, options);
+
+              if (interpreter == nullptr) {
+                callInvoker->invokeAsync([=]() {
+                  promise->reject("Failed to create TFLite interpreter from model \"" + modelPath +
+                                  "\"!");
+                });
+                return;
+              }
+
+              // Initialize Model and allocate memory buffers
+              auto plugin = std::make_shared<TensorflowPlugin>(interpreter, buffer, delegateType,
+                                                               callInvoker);
+
+              callInvoker->invokeAsync([=, &runtime]() {
+                auto result = jsi::Object::createFromHostObject(runtime, plugin);
+                promise->resolve(std::move(result));
               });
-            });
+
+              auto end = std::chrono::steady_clock::now();
+              log("Successfully loaded Tensorflow Model in %i ms!",
+                  std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count());
+            } catch (std::exception& error) {
+              std::string message = error.what();
+              callInvoker->invokeAsync([=]() { promise->reject(message); });
+            }
+          });
+        });
         return promise;
       });
 

--- a/cpp/TensorflowPlugin.h
+++ b/cpp/TensorflowPlugin.h
@@ -34,7 +34,7 @@ typedef std::function<Buffer(std::string)> FetchURLFunc;
 class TensorflowPlugin : public jsi::HostObject {
 public:
   // TFL Delegate Type
-  enum Delegate { Default, Metal, CoreML };
+  enum Delegate { Default, Metal, CoreML, NnApi, AndroidGPU };
 
 public:
   explicit TensorflowPlugin(TfLiteInterpreter* interpreter, Buffer model, Delegate delegate,

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
       android:theme="@style/AppTheme">
+      <uses-native-library android:name="libOpenCL.so" android:required="false" />
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
   - boost (1.83.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.73.2)
-  - FBReactNativeSpec (0.73.2):
+  - FBLazyVector (0.73.3)
+  - FBReactNativeSpec (0.73.3):
     - RCT-Folly (= 2022.05.16.00)
-    - RCTRequired (= 0.73.2)
-    - RCTTypeSafety (= 0.73.2)
-    - React-Core (= 0.73.2)
-    - React-jsi (= 0.73.2)
-    - ReactCommon/turbomodule/core (= 0.73.2)
+    - RCTRequired (= 0.73.3)
+    - RCTTypeSafety (= 0.73.3)
+    - React-Core (= 0.73.3)
+    - React-jsi (= 0.73.3)
+    - ReactCommon/turbomodule/core (= 0.73.3)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - hermes-engine (0.73.2):
-    - hermes-engine/Pre-built (= 0.73.2)
-  - hermes-engine/Pre-built (0.73.2)
+  - hermes-engine (0.73.3):
+    - hermes-engine/Pre-built (= 0.73.3)
+  - hermes-engine/Pre-built (0.73.3)
   - libevent (2.1.12)
   - RCT-Folly (2022.05.16.00):
     - boost
@@ -37,26 +37,26 @@ PODS:
     - fmt (~> 6.2.1)
     - glog
     - libevent
-  - RCTRequired (0.73.2)
-  - RCTTypeSafety (0.73.2):
-    - FBLazyVector (= 0.73.2)
-    - RCTRequired (= 0.73.2)
-    - React-Core (= 0.73.2)
-  - React (0.73.2):
-    - React-Core (= 0.73.2)
-    - React-Core/DevSupport (= 0.73.2)
-    - React-Core/RCTWebSocket (= 0.73.2)
-    - React-RCTActionSheet (= 0.73.2)
-    - React-RCTAnimation (= 0.73.2)
-    - React-RCTBlob (= 0.73.2)
-    - React-RCTImage (= 0.73.2)
-    - React-RCTLinking (= 0.73.2)
-    - React-RCTNetwork (= 0.73.2)
-    - React-RCTSettings (= 0.73.2)
-    - React-RCTText (= 0.73.2)
-    - React-RCTVibration (= 0.73.2)
-  - React-callinvoker (0.73.2)
-  - React-Codegen (0.73.2):
+  - RCTRequired (0.73.3)
+  - RCTTypeSafety (0.73.3):
+    - FBLazyVector (= 0.73.3)
+    - RCTRequired (= 0.73.3)
+    - React-Core (= 0.73.3)
+  - React (0.73.3):
+    - React-Core (= 0.73.3)
+    - React-Core/DevSupport (= 0.73.3)
+    - React-Core/RCTWebSocket (= 0.73.3)
+    - React-RCTActionSheet (= 0.73.3)
+    - React-RCTAnimation (= 0.73.3)
+    - React-RCTBlob (= 0.73.3)
+    - React-RCTImage (= 0.73.3)
+    - React-RCTLinking (= 0.73.3)
+    - React-RCTNetwork (= 0.73.3)
+    - React-RCTSettings (= 0.73.3)
+    - React-RCTText (= 0.73.3)
+    - React-RCTVibration (= 0.73.3)
+  - React-callinvoker (0.73.3)
+  - React-Codegen (0.73.3):
     - DoubleConversion
     - FBReactNativeSpec
     - glog
@@ -71,11 +71,11 @@ PODS:
     - React-rncore
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-Core (0.73.2):
+  - React-Core (0.73.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.2)
+    - React-Core/Default (= 0.73.3)
     - React-cxxreact
     - React-hermes
     - React-jsi
@@ -85,50 +85,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.73.2):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2022.05.16.00)
-    - React-Core/Default
-    - React-cxxreact
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.6.1)
-    - Yoga
-  - React-Core/Default (0.73.2):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2022.05.16.00)
-    - React-cxxreact
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.6.1)
-    - Yoga
-  - React-Core/DevSupport (0.73.2):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.2)
-    - React-Core/RCTWebSocket (= 0.73.2)
-    - React-cxxreact
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector (= 0.73.2)
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.6.1)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.73.2):
+  - React-Core/CoreModulesHeaders (0.73.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -142,7 +99,36 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.73.2):
+  - React-Core/Default (0.73.3):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2022.05.16.00)
+    - React-cxxreact
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.6.1)
+    - Yoga
+  - React-Core/DevSupport (0.73.3):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2022.05.16.00)
+    - React-Core/Default (= 0.73.3)
+    - React-Core/RCTWebSocket (= 0.73.3)
+    - React-cxxreact
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector (= 0.73.3)
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.6.1)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.73.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -156,7 +142,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.73.2):
+  - React-Core/RCTAnimationHeaders (0.73.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -170,7 +156,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTImageHeaders (0.73.2):
+  - React-Core/RCTBlobHeaders (0.73.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -184,7 +170,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.73.2):
+  - React-Core/RCTImageHeaders (0.73.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -198,7 +184,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.73.2):
+  - React-Core/RCTLinkingHeaders (0.73.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -212,7 +198,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.73.2):
+  - React-Core/RCTNetworkHeaders (0.73.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -226,7 +212,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTTextHeaders (0.73.2):
+  - React-Core/RCTSettingsHeaders (0.73.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -240,7 +226,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.73.2):
+  - React-Core/RCTTextHeaders (0.73.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -254,11 +240,11 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTWebSocket (0.73.2):
+  - React-Core/RCTVibrationHeaders (0.73.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.2)
+    - React-Core/Default
     - React-cxxreact
     - React-hermes
     - React-jsi
@@ -268,33 +254,47 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-CoreModules (0.73.2):
+  - React-Core/RCTWebSocket (0.73.3):
+    - glog
+    - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
-    - RCTTypeSafety (= 0.73.2)
+    - React-Core/Default (= 0.73.3)
+    - React-cxxreact
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.6.1)
+    - Yoga
+  - React-CoreModules (0.73.3):
+    - RCT-Folly (= 2022.05.16.00)
+    - RCTTypeSafety (= 0.73.3)
     - React-Codegen
-    - React-Core/CoreModulesHeaders (= 0.73.2)
-    - React-jsi (= 0.73.2)
+    - React-Core/CoreModulesHeaders (= 0.73.3)
+    - React-jsi (= 0.73.3)
     - React-NativeModulesApple
     - React-RCTBlob
-    - React-RCTImage (= 0.73.2)
+    - React-RCTImage (= 0.73.3)
     - ReactCommon
     - SocketRocket (= 0.6.1)
-  - React-cxxreact (0.73.2):
+  - React-cxxreact (0.73.3):
     - boost (= 1.83.0)
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.2)
-    - React-debug (= 0.73.2)
-    - React-jsi (= 0.73.2)
-    - React-jsinspector (= 0.73.2)
-    - React-logger (= 0.73.2)
-    - React-perflogger (= 0.73.2)
-    - React-runtimeexecutor (= 0.73.2)
-  - React-debug (0.73.2)
-  - React-Fabric (0.73.2):
+    - React-callinvoker (= 0.73.3)
+    - React-debug (= 0.73.3)
+    - React-jsi (= 0.73.3)
+    - React-jsinspector (= 0.73.3)
+    - React-logger (= 0.73.3)
+    - React-perflogger (= 0.73.3)
+    - React-runtimeexecutor (= 0.73.3)
+  - React-debug (0.73.3)
+  - React-Fabric (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -305,20 +305,20 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.73.2)
-    - React-Fabric/attributedstring (= 0.73.2)
-    - React-Fabric/componentregistry (= 0.73.2)
-    - React-Fabric/componentregistrynative (= 0.73.2)
-    - React-Fabric/components (= 0.73.2)
-    - React-Fabric/core (= 0.73.2)
-    - React-Fabric/imagemanager (= 0.73.2)
-    - React-Fabric/leakchecker (= 0.73.2)
-    - React-Fabric/mounting (= 0.73.2)
-    - React-Fabric/scheduler (= 0.73.2)
-    - React-Fabric/telemetry (= 0.73.2)
-    - React-Fabric/templateprocessor (= 0.73.2)
-    - React-Fabric/textlayoutmanager (= 0.73.2)
-    - React-Fabric/uimanager (= 0.73.2)
+    - React-Fabric/animations (= 0.73.3)
+    - React-Fabric/attributedstring (= 0.73.3)
+    - React-Fabric/componentregistry (= 0.73.3)
+    - React-Fabric/componentregistrynative (= 0.73.3)
+    - React-Fabric/components (= 0.73.3)
+    - React-Fabric/core (= 0.73.3)
+    - React-Fabric/imagemanager (= 0.73.3)
+    - React-Fabric/leakchecker (= 0.73.3)
+    - React-Fabric/mounting (= 0.73.3)
+    - React-Fabric/scheduler (= 0.73.3)
+    - React-Fabric/telemetry (= 0.73.3)
+    - React-Fabric/templateprocessor (= 0.73.3)
+    - React-Fabric/textlayoutmanager (= 0.73.3)
+    - React-Fabric/uimanager (= 0.73.3)
     - React-graphics
     - React-jsi
     - React-jsiexecutor
@@ -327,26 +327,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/animations (0.73.2):
-    - DoubleConversion
-    - fmt (~> 6.2.1)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2022.05.16.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/attributedstring (0.73.2):
+  - React-Fabric/animations (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -365,7 +346,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistry (0.73.2):
+  - React-Fabric/attributedstring (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -384,7 +365,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistrynative (0.73.2):
+  - React-Fabric/componentregistry (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -403,37 +384,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components (0.73.2):
-    - DoubleConversion
-    - fmt (~> 6.2.1)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2022.05.16.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/inputaccessory (= 0.73.2)
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.73.2)
-    - React-Fabric/components/modal (= 0.73.2)
-    - React-Fabric/components/rncore (= 0.73.2)
-    - React-Fabric/components/root (= 0.73.2)
-    - React-Fabric/components/safeareaview (= 0.73.2)
-    - React-Fabric/components/scrollview (= 0.73.2)
-    - React-Fabric/components/text (= 0.73.2)
-    - React-Fabric/components/textinput (= 0.73.2)
-    - React-Fabric/components/unimplementedview (= 0.73.2)
-    - React-Fabric/components/view (= 0.73.2)
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/components/inputaccessory (0.73.2):
+  - React-Fabric/componentregistrynative (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -452,7 +403,37 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/legacyviewmanagerinterop (0.73.2):
+  - React-Fabric/components (0.73.3):
+    - DoubleConversion
+    - fmt (~> 6.2.1)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/inputaccessory (= 0.73.3)
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.73.3)
+    - React-Fabric/components/modal (= 0.73.3)
+    - React-Fabric/components/rncore (= 0.73.3)
+    - React-Fabric/components/root (= 0.73.3)
+    - React-Fabric/components/safeareaview (= 0.73.3)
+    - React-Fabric/components/scrollview (= 0.73.3)
+    - React-Fabric/components/text (= 0.73.3)
+    - React-Fabric/components/textinput (= 0.73.3)
+    - React-Fabric/components/unimplementedview (= 0.73.3)
+    - React-Fabric/components/view (= 0.73.3)
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/inputaccessory (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -471,7 +452,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/modal (0.73.2):
+  - React-Fabric/components/legacyviewmanagerinterop (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -490,7 +471,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/rncore (0.73.2):
+  - React-Fabric/components/modal (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -509,7 +490,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/root (0.73.2):
+  - React-Fabric/components/rncore (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -528,7 +509,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/safeareaview (0.73.2):
+  - React-Fabric/components/root (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -547,7 +528,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/scrollview (0.73.2):
+  - React-Fabric/components/safeareaview (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -566,7 +547,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/text (0.73.2):
+  - React-Fabric/components/scrollview (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -585,7 +566,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/textinput (0.73.2):
+  - React-Fabric/components/text (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -604,7 +585,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/unimplementedview (0.73.2):
+  - React-Fabric/components/textinput (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -623,7 +604,26 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/view (0.73.2):
+  - React-Fabric/components/unimplementedview (0.73.3):
+    - DoubleConversion
+    - fmt (~> 6.2.1)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/view (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -643,7 +643,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric/core (0.73.2):
+  - React-Fabric/core (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -662,7 +662,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/imagemanager (0.73.2):
+  - React-Fabric/imagemanager (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -681,7 +681,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/leakchecker (0.73.2):
+  - React-Fabric/leakchecker (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -700,7 +700,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/mounting (0.73.2):
+  - React-Fabric/mounting (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -719,7 +719,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/scheduler (0.73.2):
+  - React-Fabric/scheduler (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -738,7 +738,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/telemetry (0.73.2):
+  - React-Fabric/telemetry (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -757,7 +757,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/templateprocessor (0.73.2):
+  - React-Fabric/templateprocessor (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -776,7 +776,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/textlayoutmanager (0.73.2):
+  - React-Fabric/textlayoutmanager (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -796,7 +796,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager (0.73.2):
+  - React-Fabric/uimanager (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -815,42 +815,42 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-FabricImage (0.73.2):
+  - React-FabricImage (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
-    - RCTRequired (= 0.73.2)
-    - RCTTypeSafety (= 0.73.2)
+    - RCTRequired (= 0.73.3)
+    - RCTTypeSafety (= 0.73.3)
     - React-Fabric
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.73.2)
+    - React-jsiexecutor (= 0.73.3)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - Yoga
-  - React-graphics (0.73.2):
+  - React-graphics (0.73.3):
     - glog
     - RCT-Folly/Fabric (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.2)
+    - React-Core/Default (= 0.73.3)
     - React-utils
-  - React-hermes (0.73.2):
+  - React-hermes (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
     - RCT-Folly/Futures (= 2022.05.16.00)
-    - React-cxxreact (= 0.73.2)
+    - React-cxxreact (= 0.73.3)
     - React-jsi
-    - React-jsiexecutor (= 0.73.2)
-    - React-jsinspector (= 0.73.2)
-    - React-perflogger (= 0.73.2)
-  - React-ImageManager (0.73.2):
+    - React-jsiexecutor (= 0.73.3)
+    - React-jsinspector (= 0.73.3)
+    - React-perflogger (= 0.73.3)
+  - React-ImageManager (0.73.3):
     - glog
     - RCT-Folly/Fabric
     - React-Core/Default
@@ -859,34 +859,34 @@ PODS:
     - React-graphics
     - React-rendererdebug
     - React-utils
-  - React-jserrorhandler (0.73.2):
+  - React-jserrorhandler (0.73.3):
     - RCT-Folly/Fabric (= 2022.05.16.00)
     - React-debug
     - React-jsi
     - React-Mapbuffer
-  - React-jsi (0.73.2):
+  - React-jsi (0.73.3):
     - boost (= 1.83.0)
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
-  - React-jsiexecutor (0.73.2):
+  - React-jsiexecutor (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
-    - React-cxxreact (= 0.73.2)
-    - React-jsi (= 0.73.2)
-    - React-perflogger (= 0.73.2)
-  - React-jsinspector (0.73.2)
-  - React-logger (0.73.2):
+    - React-cxxreact (= 0.73.3)
+    - React-jsi (= 0.73.3)
+    - React-perflogger (= 0.73.3)
+  - React-jsinspector (0.73.3)
+  - React-logger (0.73.3):
     - glog
-  - React-Mapbuffer (0.73.2):
+  - React-Mapbuffer (0.73.3):
     - glog
     - React-debug
-  - react-native-fast-tflite (1.1.3):
+  - react-native-fast-tflite (1.2.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -894,8 +894,8 @@ PODS:
     - React
     - React-callinvoker
     - React-Core
-  - React-nativeconfig (0.73.2)
-  - React-NativeModulesApple (0.73.2):
+  - React-nativeconfig (0.73.3)
+  - React-NativeModulesApple (0.73.3):
     - glog
     - hermes-engine
     - React-callinvoker
@@ -905,10 +905,10 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.73.2)
-  - React-RCTActionSheet (0.73.2):
-    - React-Core/RCTActionSheetHeaders (= 0.73.2)
-  - React-RCTAnimation (0.73.2):
+  - React-perflogger (0.73.3)
+  - React-RCTActionSheet (0.73.3):
+    - React-Core/RCTActionSheetHeaders (= 0.73.3)
+  - React-RCTAnimation (0.73.3):
     - RCT-Folly (= 2022.05.16.00)
     - RCTTypeSafety
     - React-Codegen
@@ -916,7 +916,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTAppDelegate (0.73.2):
+  - React-RCTAppDelegate (0.73.3):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -930,7 +930,7 @@ PODS:
     - React-RCTNetwork
     - React-runtimescheduler
     - ReactCommon
-  - React-RCTBlob (0.73.2):
+  - React-RCTBlob (0.73.3):
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
     - React-Codegen
@@ -940,7 +940,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTFabric (0.73.2):
+  - React-RCTFabric (0.73.3):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -958,7 +958,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - Yoga
-  - React-RCTImage (0.73.2):
+  - React-RCTImage (0.73.3):
     - RCT-Folly (= 2022.05.16.00)
     - RCTTypeSafety
     - React-Codegen
@@ -967,14 +967,14 @@ PODS:
     - React-NativeModulesApple
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTLinking (0.73.2):
+  - React-RCTLinking (0.73.3):
     - React-Codegen
-    - React-Core/RCTLinkingHeaders (= 0.73.2)
-    - React-jsi (= 0.73.2)
+    - React-Core/RCTLinkingHeaders (= 0.73.3)
+    - React-jsi (= 0.73.3)
     - React-NativeModulesApple
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.73.2)
-  - React-RCTNetwork (0.73.2):
+    - ReactCommon/turbomodule/core (= 0.73.3)
+  - React-RCTNetwork (0.73.3):
     - RCT-Folly (= 2022.05.16.00)
     - RCTTypeSafety
     - React-Codegen
@@ -982,7 +982,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTSettings (0.73.2):
+  - React-RCTSettings (0.73.3):
     - RCT-Folly (= 2022.05.16.00)
     - RCTTypeSafety
     - React-Codegen
@@ -990,25 +990,25 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTText (0.73.2):
-    - React-Core/RCTTextHeaders (= 0.73.2)
+  - React-RCTText (0.73.3):
+    - React-Core/RCTTextHeaders (= 0.73.3)
     - Yoga
-  - React-RCTVibration (0.73.2):
+  - React-RCTVibration (0.73.3):
     - RCT-Folly (= 2022.05.16.00)
     - React-Codegen
     - React-Core/RCTVibrationHeaders
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-rendererdebug (0.73.2):
+  - React-rendererdebug (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - RCT-Folly (= 2022.05.16.00)
     - React-debug
-  - React-rncore (0.73.2)
-  - React-runtimeexecutor (0.73.2):
-    - React-jsi (= 0.73.2)
-  - React-runtimescheduler (0.73.2):
+  - React-rncore (0.73.3)
+  - React-runtimeexecutor (0.73.3):
+    - React-jsi (= 0.73.3)
+  - React-runtimescheduler (0.73.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -1019,48 +1019,48 @@ PODS:
     - React-rendererdebug
     - React-runtimeexecutor
     - React-utils
-  - React-utils (0.73.2):
+  - React-utils (0.73.3):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-debug
-  - ReactCommon (0.73.2):
-    - React-logger (= 0.73.2)
-    - ReactCommon/turbomodule (= 0.73.2)
-  - ReactCommon/turbomodule (0.73.2):
+  - ReactCommon (0.73.3):
+    - React-logger (= 0.73.3)
+    - ReactCommon/turbomodule (= 0.73.3)
+  - ReactCommon/turbomodule (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.2)
-    - React-cxxreact (= 0.73.2)
-    - React-jsi (= 0.73.2)
-    - React-logger (= 0.73.2)
-    - React-perflogger (= 0.73.2)
-    - ReactCommon/turbomodule/bridging (= 0.73.2)
-    - ReactCommon/turbomodule/core (= 0.73.2)
-  - ReactCommon/turbomodule/bridging (0.73.2):
+    - React-callinvoker (= 0.73.3)
+    - React-cxxreact (= 0.73.3)
+    - React-jsi (= 0.73.3)
+    - React-logger (= 0.73.3)
+    - React-perflogger (= 0.73.3)
+    - ReactCommon/turbomodule/bridging (= 0.73.3)
+    - ReactCommon/turbomodule/core (= 0.73.3)
+  - ReactCommon/turbomodule/bridging (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.2)
-    - React-cxxreact (= 0.73.2)
-    - React-jsi (= 0.73.2)
-    - React-logger (= 0.73.2)
-    - React-perflogger (= 0.73.2)
-  - ReactCommon/turbomodule/core (0.73.2):
+    - React-callinvoker (= 0.73.3)
+    - React-cxxreact (= 0.73.3)
+    - React-jsi (= 0.73.3)
+    - React-logger (= 0.73.3)
+    - React-perflogger (= 0.73.3)
+  - ReactCommon/turbomodule/core (0.73.3):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.2)
-    - React-cxxreact (= 0.73.2)
-    - React-jsi (= 0.73.2)
-    - React-logger (= 0.73.2)
-    - React-perflogger (= 0.73.2)
+    - React-callinvoker (= 0.73.3)
+    - React-cxxreact (= 0.73.3)
+    - React-jsi (= 0.73.3)
+    - React-logger (= 0.73.3)
+    - React-perflogger (= 0.73.3)
   - SocketRocket (0.6.1)
   - vision-camera-resize-plugin (2.0.1):
     - glog
@@ -1247,59 +1247,59 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
-  FBLazyVector: fbc4957d9aa695250b55d879c1d86f79d7e69ab4
-  FBReactNativeSpec: 86de768f89901ef6ed3207cd686362189d64ac88
+  FBLazyVector: 70590b4f9e8ae9b0ce076efacea3abd7bc585ace
+  FBReactNativeSpec: e47ea8c8f044c25e41a4fa5e8b7ff3923d3e0a94
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
-  hermes-engine: b361c9ef5ef3cda53f66e195599b47e1f84ffa35
+  hermes-engine: 5420539d016f368cd27e008f65f777abd6098c56
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
-  RCTRequired: 9b1e7e262745fb671e33c51c1078d093bd30e322
-  RCTTypeSafety: a759e3b086eccf3e2cbf2493d22f28e082f958e6
-  React: 805f5dd55bbdb92c36b4914c64aaae4c97d358dc
-  React-callinvoker: 6a697867607c990c2c2c085296ee32cfb5e47c01
-  React-Codegen: c4447ffa339f4e7a22e0c9c800eec9084f31899c
-  React-Core: 49f66fecc7695464e9b7bc7dc7cd9473d2c60584
-  React-CoreModules: 710e7c557a1a8180bd1645f5b4bf79f4bd3f5417
-  React-cxxreact: 345857b5e4be000c0527df78be3b41a0677a20ce
-  React-debug: f1637bce73342b2f6eee4982508fdfb088667a87
-  React-Fabric: 4dfcff8f14d8e5a7a60b11b7862dad2a9d99c65b
-  React-FabricImage: 4a9e9510b7f28bbde6a743b18c0cb941a142e938
-  React-graphics: dd5af9d8b1b45171fd6933e19fed522f373bcb10
-  React-hermes: a52d183a5cf8ccb7020ce3df4275b89d01e6b53e
-  React-ImageManager: c5b7db131eff71443d7f3a8d686fd841d18befd3
-  React-jserrorhandler: 97a6a12e2344c3c4fdd7ba1edefb005215c732f8
-  React-jsi: a182068133f80918cd0eec77875abaf943a0b6be
-  React-jsiexecutor: dacd00ce8a18fc00a0ae6c25e3015a6437e5d2e8
-  React-jsinspector: 03644c063fc3621c9a4e8bf263a8150909129618
-  React-logger: 66b168e2b2bee57bd8ce9e69f739d805732a5570
-  React-Mapbuffer: 9ee041e1d7be96da6d76a251f92e72b711c651d6
-  react-native-fast-tflite: 369d7ded6d82a878fb481ab772c26804a2a797f0
+  RCTRequired: 9b898847f76977a6dfed2a08f4c5ed37add75ec0
+  RCTTypeSafety: 0debdc4ba38c8138016d8d8ada4bdf9ec1b8aa82
+  React: f8afb04431634ac7e9b876dc96d30af9871f5946
+  React-callinvoker: 5ea86c3f93326867aa5114989d229db54d4759d0
+  React-Codegen: f8f3172b716f793b334e6603b3b33207c0e813c7
+  React-Core: bbac074eba495788a01d1e5455b132872bf86843
+  React-CoreModules: 92fee6d8f4095e151b9678e44fcf0dc8eabeae37
+  React-cxxreact: e856e0370bf52aea71acce10007ad9ba6a63b66c
+  React-debug: 23ea1f904cd98ae3b04b2b4982584641d3c7bcb5
+  React-Fabric: f692e74b325a408f328d337615a22539315d8a90
+  React-FabricImage: 969993a105d5e2a9bfab6945b78b88a2b0d70504
+  React-graphics: f95976953fc89d60b1022a4ea3d8281985993fe7
+  React-hermes: ac421eebea18bab58a57b70c590b7c11edaac00b
+  React-ImageManager: d67a26f14b62ff5a0c86c36d5d580940f4f07771
+  React-jserrorhandler: 7087c3b3d9691ba72798adf600a4157beeb16fd7
+  React-jsi: 57498df51dfb8a37a996f470a457d8797e931eaa
+  React-jsiexecutor: d83a7d7aea2ffc60dbda0f3d523578a76820f0e1
+  React-jsinspector: 6fad0fe14882fb6b1c32e5cc8a4bd3d33a8b6790
+  React-logger: cb0dd15ac67b00e7b771ef15203edcb29d4a3f8e
+  React-Mapbuffer: d59258be3b0d2280c6ba8964ab6e36ec69211871
+  react-native-fast-tflite: a9574c72f0d3e9efb916953926d089f65326c66b
   react-native-worklets-core: a894d572639fcf37c6d284cc799882d25d00c93d
-  React-nativeconfig: d753fbbc8cecc8ae413d615599ac378bbf6999bb
-  React-NativeModulesApple: 964f4eeab1b4325e8b6a799cf4444c3fd4eb0a9c
-  React-perflogger: 29efe63b7ef5fbaaa50ef6eaa92482f98a24b97e
-  React-RCTActionSheet: 69134c62aefd362027b20da01cd5d14ffd39db3f
-  React-RCTAnimation: 3b5a57087c7a5e727855b803d643ac1d445488f5
-  React-RCTAppDelegate: a3ce9b69c0620a1717d08e826d4dc7ad8a3a3cae
-  React-RCTBlob: 26ea660f2be1e6de62f2d2ad9a9c7b9bfabb786f
-  React-RCTFabric: bb6dbbff2f80b9489f8b2f1d2554aa040aa2e3cd
-  React-RCTImage: 27b27f4663df9e776d0549ed2f3536213e793f1b
-  React-RCTLinking: 962880ce9d0e2ea83fd182953538fc4ed757d4da
-  React-RCTNetwork: 73a756b44d4ad584bae13a5f1484e3ce12accac8
-  React-RCTSettings: 6d7f8d807f05de3d01cfb182d14e5f400716faac
-  React-RCTText: 73006e95ca359595c2510c1c0114027c85a6ddd3
-  React-RCTVibration: 599f427f9cbdd9c4bf38959ca020e8fef0717211
-  React-rendererdebug: f2946e0a1c3b906e71555a7c4a39aa6a6c0e639b
-  React-rncore: 74030de0ffef7b1a3fb77941168624534cc9ae7f
-  React-runtimeexecutor: 2d1f64f58193f00a3ad71d3f89c2bfbfe11cf5a5
-  React-runtimescheduler: df8945a656356ff10f58f65a70820478bfcf33ad
-  React-utils: f5bc61e7ea3325c0732ae2d755f4441940163b85
-  ReactCommon: 45b5d4f784e869c44a6f5a8fad5b114ca8f78c53
+  React-nativeconfig: 4d3076dc3dc498ec49819e4e4225b55d3507f902
+  React-NativeModulesApple: 46f14baf36010b22ffd84fd89d5586e4148edfb3
+  React-perflogger: 27ccacf853ba725524ef2b4e444f14e34d0837b0
+  React-RCTActionSheet: 77dd6a2a5cfab9e85b7f1add0f7e2e9cd697d936
+  React-RCTAnimation: 977a25a4e8007ecc90e556abcceb1b25602eea7c
+  React-RCTAppDelegate: 252a478047dbc9d0ac0dcda7440b4d3fbb6184a4
+  React-RCTBlob: 1e18ab09f57cf3bd2b9681cbeedfca866d971f50
+  React-RCTFabric: f09af5b9aac819d8c362ef3030b2d16be426c176
+  React-RCTImage: b1eac9526111cf7e37c304f94e81b76a5ae6a984
+  React-RCTLinking: d7f7dc665af6442ff38e18e34308da7865347bb1
+  React-RCTNetwork: c2c1df3a3c838e9547259e3638f6b290aebb3b72
+  React-RCTSettings: f3074b14047a57fa95499c28fb89028a894d3c18
+  React-RCTText: 9d48b2bbce5e1ed9c4d9514414dc6d99731d1b0a
+  React-RCTVibration: 394ea84082b08b5b3c211dc2bc9c0c4c163e7f23
+  React-rendererdebug: 3445e5d7d8fa3c66974d779b6a77b41186224b0f
+  React-rncore: bfb1b25c3e6ce9535708a7ac109c91fed3c8085b
+  React-runtimeexecutor: 7e71a40def8262ef7d82a1145d873ea61b1a27b5
+  React-runtimescheduler: aa382ce525689b88459e1181b3649220f175dc31
+  React-utils: b22b4a51aa578b3aac1e7c19501c0b9ba358ed79
+  ReactCommon: e708b8be8cb317b83e31c6ccfeda8bf6c0d1a2b3
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   vision-camera-resize-plugin: 536345c29f42e04438d34d0cada7b4992a8fc104
   VisionCamera: edbcd00e27a438b2228f67823e2b8d15a189065f
-  Yoga: e64aa65de36c0832d04e8c7bd614396c77a80047
+  Yoga: 08cd7601462818c4985bda7b205b9e6a92a7e66a
 
 PODFILE CHECKSUM: 33c2f84b68c18fe6787cbe3e723675d15fcc7e66
 

--- a/example/ios/TfliteExample.xcodeproj/project.pbxproj
+++ b/example/ios/TfliteExample.xcodeproj/project.pbxproj
@@ -607,11 +607,7 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;
@@ -678,11 +674,7 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/package.json
+++ b/package.json
@@ -140,5 +140,6 @@
         }
       ]
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
 }

--- a/src/TensorflowLite.ts
+++ b/src/TensorflowLite.ts
@@ -33,7 +33,12 @@ if (result !== true)
 
 console.log('Successfully installed!')
 
-export type TensorflowModelDelegate = 'default' | 'metal' | 'core-ml'
+export type TensorflowModelDelegate =
+  | 'default'
+  | 'metal'
+  | 'core-ml'
+  | 'nnapi'
+  | 'android-gpu'
 
 export interface Tensor {
   /**


### PR DESCRIPTION
Had tested on Redmi X3, POCO X6 and Samsung Galaxy M. 

The improvement on the example app is not really big but had notice significant improvement on larger model by 12~16 times compared to default CPU delegate, in exchange with slightly longer initial model load time. For my personal model, it takes twice the time need to load the model with GPU compared to CPU, but definitely still preferable over due to the much faster inference time

Though it is **not** tested on iOS yet. ~~I meant for error raised only XD~~

Closes https://github.com/mrousavy/react-native-fast-tflite/issues/47