### PR TITLE
fix: android build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,6 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    labels:
-      - "dependencies"
   # - package-ecosystem: "npm"
   #   directory: "./"
   #   schedule:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tensorflow"]
-	path = tensorflow
-	url = https://github.com/tensorflow/tensorflow

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -54,8 +54,19 @@ target_link_libraries(
   ${PACKAGE_NAME}
   android                         # <-- log
   ReactAndroid::jsi               # <-- jsi.h
-  ReactAndroid::reactnativejni    # <-- CallInvokerImpl
   fbjni::fbjni                    # <-- fbjni.h
   ${TFLITE}
   ${TFLITE_GPU}
 )
+
+if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
+  target_link_libraries(
+    ${PACKAGE_NAME}
+    ReactAndroid::reactnative     # <-- RN merged so
+  )
+else()
+  target_link_libraries(
+    ${PACKAGE_NAME}
+    ReactAndroid::reactnativejni  # <-- CallInvokerImpl
+  )
+endif()

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(fbjni REQUIRED CONFIG)
 find_library(
   TFLITE
   tensorflowlite_jni
-  PATHS "./src/main/cpp/lib/tensorflow/jni/${ANDROID_ABI}"
+  PATHS "./src/main/cpp/lib/litert/jni/${ANDROID_ABI}"
   NO_DEFAULT_PATH
   NO_CMAKE_FIND_ROOT_PATH
 )
@@ -19,7 +19,7 @@ find_library(
 find_library(
   TFLITE_GPU
   tensorflowlite_gpu_jni
-  PATHS "./src/main/cpp/lib/tensorflow/jni/${ANDROID_ABI}"
+  PATHS "./src/main/cpp/lib/litert/jni/${ANDROID_ABI}"
   NO_DEFAULT_PATH
   NO_CMAKE_FIND_ROOT_PATH
 )
@@ -42,7 +42,7 @@ target_include_directories(
   PRIVATE
   "../cpp"
   "src/main/cpp"
-  "../tensorflow/"
+  "src/main/cpp/lib/litert/headers"
   "${NODE_MODULES_DIR}/react-native/ReactCommon"
   "${NODE_MODULES_DIR}/react-native/ReactCommon/callinvoker"
   "${NODE_MODULES_DIR}/react-native/ReactAndroid/src/main/jni/react/turbomodule" # <-- CallInvokerHolder JNI wrapper

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -80,6 +80,7 @@ android {
             "**/libc++_shared.so",
             "**/libfbjni.so",
             "**/libjsi.so",
+            "**/libreactnative.so",
             "**/libreactnativejni.so",
             "**/libturbomodulejsijni.so",
             "**/libreact_nativemodule_core.so",

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,6 +84,8 @@ android {
             "**/libreactnativejni.so",
             "**/libturbomodulejsijni.so",
             "**/libreact_nativemodule_core.so",
+            "**/libtensorflowlite_jni.so",
+            "**/libtensorflowlite_gpu_jni.so",
     ]
   }
   buildTypes {
@@ -124,12 +126,28 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
 
   // Tensorflow Lite .aar (includes C API via prefabs)
-  implementation "org.tensorflow:tensorflow-lite:2.16.1"
-  extractSO("org.tensorflow:tensorflow-lite:2.16.1")
+  implementation "com.google.ai.edge.litert:litert:1.0.1"
+  extractSO("com.google.ai.edge.litert:litert:1.0.1")
+  extractHeaders("com.google.ai.edge.litert:litert:1.0.1")
 
   // Tensorflow Lite GPU delegate
-  implementation "org.tensorflow:tensorflow-lite-gpu:2.16.1"
-  extractSO("org.tensorflow:tensorflow-lite-gpu:2.16.1")
+  implementation "com.google.ai.edge.litert:litert-gpu:1.0.1"
+  extractSO("com.google.ai.edge.litert:litert-gpu:1.0.1")
+  extractHeaders("com.google.ai.edge.litert:litert-gpu:1.0.1")
+}
+
+task extractAARHeaders {
+  doLast {
+    configurations.extractHeaders.files.each {
+      def file = it.absoluteFile
+      def packageName = file.name.tokenize('-')[0]
+      copy {
+        from zipTree(file)
+        into "src/main/cpp/lib/$packageName/"
+        include "**/*.h"
+      }
+    }
+  }
 }
 
 task extractSOFiles {
@@ -167,5 +185,6 @@ def nativeBuildDependsOn(dependsOnTask) {
 }
 
 afterEvaluate {
+  nativeBuildDependsOn(extractAARHeaders)
   nativeBuildDependsOn(extractSOFiles)
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "src",
     "lib",
     "android/src",
+    "!android/src/main/cpp/lib",
     "android/build.gradle",
     "android/CMakeLists.txt",
     "android/gradle.properties",

--- a/package.json
+++ b/package.json
@@ -27,14 +27,11 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\" --fix",
     "lint-cpp": "scripts/clang-format.sh",
-    "prepare": "git submodule update --init --recursive",
-    "update-submodule": "git submodule update --remote --merge",
     "check-all": "scripts/check-all.sh",
     "prepack": "bob build",
     "release": "release-it",
     "example": "yarn --cwd example",
-    "configure": "git submodule update --init --recursive && cd tensorflow && ./configure",
-    "bootstrap": "yarn && yarn example && yarn example pods && yarn configure"
+    "bootstrap": "yarn && yarn example && yarn example pods"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
### Summary

- **Compatibility**: Supports React Native merged `.so` changes introduced in version 0.76.  
- **LiteRT Migration**: Adopts LiteRT(It's new name for TensorFlow), updating to [LiteRT v1.0.1](https://github.com/google-ai-edge/LiteRT/releases/tag/v1.0.1), which includes TensorFlow 2.17.0.  
  - Resolves header issues in the Android build process. (Closes #91, #99, #118)  
  - Ensures alignment with the same TensorFlow version used on iOS.  
- **Submodule Removal**: Eliminates the submodule as pre-building is no longer required with the updated setup.