### PR TITLE
fix: TypedArray cache cleanup

### DIFF
--- a/android/src/main/cpp/Tflite.cpp
+++ b/android/src/main/cpp/Tflite.cpp
@@ -30,6 +30,16 @@ public:
     }
     auto jsCallInvoker = jsCallInvokerHolder->cthis()->getCallInvoker();
 
+
+    // Adds the PropNameIDCache object to the Runtime. If the Runtime gets
+    // destroyed, the Object gets destroyed and the cache gets invalidated.
+    auto propNameIdCache = std::make_shared<InvalidateCacheOnDestroy>(runtime);
+    runtime.global().setProperty(
+      runtime,
+      "tfPluginPropNameIdCache",
+      jsi::Object::createFromHostObject(runtime, propNameIdCache)
+    );
+
     auto fetchByteDataFromUrl = [](std::string url) {
       // Attaching Current Thread to JVM
       JNIEnv* env = nullptr;


### PR DESCRIPTION
This seemed to be missing, compared to the other fix PRs, but maybe this library uses TypedArray cpp differently?

My app is no longer growing memory use at ~200-300MB per HMR anymore.  However, I have noticed crashes in VisionCamera now.
