### PR TITLE
fix codegen error:  no such file or directory, lstat '..\spec'

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "!ios/build",
     "cpp",
     "*.podspec",
-    "app.plugin.js"
+    "app.plugin.js",
+    "spec"
   ],
   "scripts": {
     "typescript": "tsc --noEmit",


### PR DESCRIPTION
Fixes this codegen error:
```
Error: ENOENT: no such file or directory, lstat '..\spec'
```
as the `spec` folder is missing in the npm package