### PR TITLE
fix(ios): Fix iOS build with new architecture enabled

### DIFF
--- a/ios/Tflite.h
+++ b/ios/Tflite.h
@@ -1,6 +1,6 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 
-#import "RNTfliteSpec.h"
+#import <RNTfliteSpec/RNTfliteSpec.h>
 @interface Tflite : NSObject <NativeRNTfliteSpec>
 @end
 

--- a/react-native-fast-tflite.podspec
+++ b/react-native-fast-tflite.podspec
@@ -42,14 +42,14 @@ Pod::Spec.new do |s|
   # Don't install the dependencies when we run `pod install` in the old architecture.
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
     s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
+    # Merge with existing pod_target_xcconfig to preserve TensorFlow Lite settings
+    s.pod_target_xcconfig = s.pod_target_xcconfig.merge({
         "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-        'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
-        "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-        "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-    }
+        "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
+    })
     s.dependency "React-Codegen"
     s.dependency "RCT-Folly"
+    s.dependency "RCT-RCTFabric"
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"
     s.dependency "ReactCommon/turbomodule/core"


### PR DESCRIPTION
Fixes issue where iOS build fails with "RNTfliteSpec.h file not found" when React Native new architecture (TurboModules) is enabled.

Changes:
1. Podspec: Merge pod_target_xcconfig instead of overwriting to preserve TensorFlow Lite settings when new architecture is enabled
2. Podspec: Add RCT-RCTFabric dependency for Fabric support
3. Podspec: Remove duplicate CLANG_CXX_LANGUAGE_STANDARD entries
4. iOS: Update RNTfliteSpec.h import to use correct path format (<RNTfliteSpec/RNTfliteSpec.h> instead of "RNTfliteSpec.h")

The issue was caused by:
- pod_target_xcconfig being redefined instead of merged, losing TensorFlow Lite preprocessor definitions
- Incorrect header import path for Codegen-generated spec file

Resolves: #87