### PR TITLE
fix: Initialize CoreML delegate options to enable all devices

### DIFF
--- a/cpp/TensorflowPlugin.cpp
+++ b/cpp/TensorflowPlugin.cpp
@@ -89,7 +89,7 @@ void TensorflowPlugin::installToRuntime(jsi::Runtime& runtime,
               switch (delegateType) {
                 case Delegate::CoreML: {
 #if FAST_TFLITE_ENABLE_CORE_ML
-                  TfLiteCoreMlDelegateOptions delegateOptions;
+                  TfLiteCoreMlDelegateOptions delegateOptions = { TfLiteCoreMlDelegateAllDevices };
                   auto delegate = TfLiteCoreMlDelegateCreate(&delegateOptions);
                   TfLiteInterpreterOptionsAddDelegate(options, delegate);
                   break;


### PR DESCRIPTION
`TfLiteCoreMlDelegateOptions` was declared without any initialization, leaving all its fields (`enabled_devices`, `coreml_version`, `max_delegated_partitions`, `min_nodes_per_partition`) with indeterminate values. This could cause unpredictable behavior when creating the CoreML delegate.                                                                                                                
                                                                                                                                                                                                          
Unlike the NNAPI and Android GPU delegates which use explicit `*Default()` initializer functions, the CoreML delegate API doesn't provide one. This fix initializes the struct with `TfLiteCoreMlDelegateAllDevices` for `enabled_devices` (so the delegate works on any device that supports CoreML, not just those with a Neural Engine), while zero-initializing the remaining fields, which  the delegate creation function handles with sensible internal defaults. 