### PR TITLE
docs: add required delegates array to README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ A high-performance [TensorFlow Lite](https://www.tensorflow.org/lite) library fo
 
    ```ts
    // Option A: Standalone Function
-   const model = await loadTensorflowModel(require('assets/my-model.tflite'))
+   const model = await loadTensorflowModel(require('assets/my-model.tflite'), [])
 
    // Option B: Hook in a Function Component
-   const plugin = useTensorflowModel(require('assets/my-model.tflite'))
+   const plugin = useTensorflowModel(require('assets/my-model.tflite'), [])
    ```
 
 4. Call the Model:
@@ -60,13 +60,14 @@ Models can be loaded from the React Native bundle via `require(..)`, or any URI/
 
 ```ts
 // Asset from React Native Bundle
-loadTensorflowModel(require('assets/my-model.tflite'))
+loadTensorflowModel(require('assets/my-model.tflite'), [])
 // File on the local filesystem
-loadTensorflowModel({ url: 'file:///var/mobile/.../my-model.tflite' })
+loadTensorflowModel({ url: 'file:///var/mobile/.../my-model.tflite' }, [])
 // Remote URL
-loadTensorflowModel({
-  url: 'https://tfhub.dev/google/lite-model/object_detection_v1.tflite',
-})
+loadTensorflowModel(
+  { url: 'https://tfhub.dev/google/lite-model/object_detection_v1.tflite' },
+  []
+)
 ```
 
 Loading a Model is asynchronous since buffers need to be allocated. Make sure to handle errors when loading.
@@ -98,7 +99,7 @@ Use [vision-camera-resize-plugin](https://github.com/mrousavy/vision-camera-resi
 ```tsx
 import { NitroModules } from 'react-native-nitro-modules'
 
-const objectDetection = useTensorflowModel(require('object_detection.tflite'))
+const objectDetection = useTensorflowModel(require('object_detection.tflite'), [])
 const model =
   objectDetection.state === 'loaded' ? objectDetection.model : undefined
 


### PR DESCRIPTION
Updating docs to avoid these sort of [issues](https://github.com/mrousavy/react-native-fast-tflite/issues/181)