### PR TITLE
fix(android): return created GPU delegate from getAndroidGPUDelegate

### DIFF
--- a/cpp/TfliteHelpers.cpp
+++ b/cpp/TfliteHelpers.cpp
@@ -164,6 +164,7 @@ TfLiteDelegate* getAndroidGPUDelegate() {
 #ifdef ANDROID
   TfLiteGpuDelegateOptionsV2 delegateOptions = TfLiteGpuDelegateOptionsV2Default();
   TfLiteDelegate* gpuDelegate = TfLiteGpuDelegateV2Create(&delegateOptions);
+  return gpuDelegate;
 #else // ANDROID
   throw std::runtime_error(
       "The Android GPU Delegate (\"android-gpu\") is only supported on Android!");


### PR DESCRIPTION
## Bug

`getAndroidGPUDelegate()` in `cpp/TfliteHelpers.cpp` creates a GPU delegate but never returns it:

```cpp
TfLiteDelegate* getAndroidGPUDelegate() {
#ifdef ANDROID
  TfLiteGpuDelegateOptionsV2 delegateOptions = TfLiteGpuDelegateOptionsV2Default();
  TfLiteDelegate* gpuDelegate = TfLiteGpuDelegateV2Create(&delegateOptions);
  // <-- missing return here
#else // ANDROID
  throw std::runtime_error(...);
#endif
}
```

The function falls off the end of the `#ifdef ANDROID` branch, returning an indeterminate value — undefined behavior. The Android GPU delegate path is completely unusable at runtime as a result.

## Fix

Add the missing `return gpuDelegate;` after the `TfLiteGpuDelegateV2Create` call:

```diff
   TfLiteDelegate* gpuDelegate = TfLiteGpuDelegateV2Create(&delegateOptions);
+  return gpuDelegate;
 #else // ANDROID
```

## Pattern

This mirrors the existing pattern in `getNNAPIDelegate()` immediately above it in the same file (lines 153–161):

```cpp
TfLiteDelegate* getNNAPIDelegate() {
#ifdef ANDROID
  TfLiteNnapiDelegateOptions delegateOptions = TfLiteNnapiDelegateOptionsDefault();
  TfLiteDelegate* nnapiDelegate = TfLiteNnapiDelegateCreate(&delegateOptions);
  return nnapiDelegate;  // ← same pattern
#else // ANDROID
  throw std::runtime_error(...);
#endif
}
```

Both functions now follow: create → return inside `#ifdef ANDROID`, throw in the `#else` branch.