### PR TITLE
fix(android): load bundled res/raw assets in release builds

### DIFF
--- a/android/src/main/java/com/margelo/nitro/tflite/HybridAssetLoader.kt
+++ b/android/src/main/java/com/margelo/nitro/tflite/HybridAssetLoader.kt
@@ -2,6 +2,7 @@ package com.margelo.nitro.tflite
 
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
+import com.margelo.nitro.NitroModules
 import com.margelo.nitro.core.ArrayBuffer
 import com.margelo.nitro.core.Promise
 import java.net.URL
@@ -11,7 +12,21 @@ import java.net.URL
 class HybridAssetLoader : HybridAssetLoaderSpec() {
   override fun loadAsset(path: String): Promise<ArrayBuffer> {
     return Promise.async {
-      val bytes = URL(path).readBytes()
+      val bytes = if (path.startsWith("http://") ||
+                      path.startsWith("https://") ||
+                      path.startsWith("file://")) {
+        URL(path).readBytes()
+      } else {
+        // In release builds, RN's AssetSourceResolver returns a bare Android
+        // resource identifier (e.g. "app_assets_yolo_nas_pose_n_320_gpu_fp16")
+        // for non-drawable extensions packaged into res/raw. java.net.URL cannot
+        // read these — resolve via the app Context / Resources instead.
+        val ctx = NitroModules.applicationContext
+          ?: throw IllegalStateException("No ReactApplicationContext available to resolve asset: $path")
+        val resId = ctx.resources.getIdentifier(path, "raw", ctx.packageName)
+        if (resId == 0) throw IllegalArgumentException("Asset not found in res/raw: $path")
+        ctx.resources.openRawResource(resId).use { it.readBytes() }
+      }
       return@async ArrayBuffer.copy(bytes)
     }
   }


### PR DESCRIPTION
## Problem

On Android release builds, `loadTensorflowModel(require('./model.tflite'))` fails with "Error loading model" (`MalformedURLException` in logcat). Dev builds work fine. This is a regression from v2.x, which loaded bundled models correctly.

## Root cause

`HybridAssetLoader.loadAsset` uses `java.net.URL(path).readBytes()`:

https://github.com/mrousavy/react-native-fast-tflite/blob/main/android/src/main/java/com/margelo/nitro/tflite/HybridAssetLoader.kt#L12-L17

The `path` comes from React Native's `AssetSourceResolver.resolve()` (via `Image.resolveAssetSource(require(...))` in `loadTensorflowModel.ts`):

- **Dev (Metro):** URI is `http://localhost:8081/assets/...` → `URL(...)` works.
- **Release:** for non-drawable extensions like `.tflite` (packaged into `res/raw/`), `AssetSourceResolver` returns a **bare Android resource identifier** with no scheme — e.g. `myapp_assets_model`. `new URL("myapp_assets_...")` throws `MalformedURLException`.

v2.x used `AssetManager` / `Resources` and handled this correctly; the Nitro rewrite in v3 dropped that path.

## Fix

Branch on the scheme. Keep `URL(...)` for `http://`, `https://`, `file://` (dev, user URLs, downloaded models). For schemeless paths, resolve the resource id via the app `Context` exposed by `NitroModules.applicationContext` and read it with `Resources.openRawResource()`.

No public API change. iOS is untouched (`HybridAssetLoader.swift` uses a different path and is unaffected).

## Testing

- Dev build (`npx react-native run-android`): model loads as before — `http://` branch.
- Release build (`./gradlew assembleRelease`): model loads successfully — new `res/raw` branch.
- Loading a model from a `file://` path (downloaded at runtime) continues to work — `file://` branch.

Fixes the "Error loading model" regression reported after upgrading to v3.