### PR TITLE
fix(android): load require() TFLite models from res/raw in release builds

### DIFF
--- a/android/src/main/java/com/margelo/nitro/tflite/HybridAssetLoader.kt
+++ b/android/src/main/java/com/margelo/nitro/tflite/HybridAssetLoader.kt
@@ -1,7 +1,10 @@
 package com.margelo.nitro.tflite
 
+import android.annotation.SuppressLint
+import android.util.Log
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
+import com.margelo.nitro.NitroModules
 import com.margelo.nitro.core.ArrayBuffer
 import com.margelo.nitro.core.Promise
 import java.net.URL
@@ -11,8 +14,32 @@ import java.net.URL
 class HybridAssetLoader : HybridAssetLoaderSpec() {
   override fun loadAsset(path: String): Promise<ArrayBuffer> {
     return Promise.async {
-      val bytes = URL(path).readBytes()
+      Log.i(TAG, "Loading TFLite model from \"$path\"...")
+      // In release builds `require(..)` resolves to a scheme-less `res/raw` resource name,
+      // which `java.net.URL` cannot parse. Load those from resources; everything with a
+      // scheme (`http(s)://` dev server, `file://` local file) goes through URL.
+      val bytes = if (path.contains("://")) loadFromUrl(path) else loadFromRawResource(path)
+      Log.i(TAG, "Successfully loaded TFLite model from \"$path\"! (${bytes.size} bytes)")
       return@async ArrayBuffer.copy(bytes)
     }
+  }
+
+  private fun loadFromUrl(path: String): ByteArray {
+    Log.i(TAG, "Loading \"$path\" from URL...")
+    return URL(path).readBytes()
+  }
+
+  @SuppressLint("DiscouragedApi")
+  private fun loadFromRawResource(path: String): ByteArray {
+    Log.i(TAG, "Loading \"$path\" from res/raw...")
+    val context =
+      NitroModules.applicationContext
+        ?: throw Error("Cannot load TFLite model - No Android Context available!")
+    val rawResourceId: Int = context.resources.getIdentifier(path, "raw", context.packageName)
+    if (rawResourceId == 0) {
+      throw Error("Cannot find TFLite model \"$path\" in res/raw!")
+    }
+    Log.i(TAG, "Resolved \"$path\" to res/raw resource ID $rawResourceId.")
+    return context.resources.openRawResource(rawResourceId).use { it.readBytes() }
   }
 }


### PR DESCRIPTION
Fixes #191.

In v3.0.1, `HybridAssetLoader` loads everything via `URL(path).readBytes()`. In release, `require('….tflite')` resolves to a scheme-less `res/raw` name (e.g. `assets_efficientdet`), which `URL` can't parse (`MalformedURLException: no protocol`), so bundled models fail to load. This worked in v1/v2 and broke in the Nitro migration.

**Fix:** branch on the URL scheme - scheme-carrying paths (`http(s)://`, `file://`) go through `URL`; scheme-less names load from `res/raw` via `getIdentifier` + `openRawResource`.

**Tested** on a physical Android device: release (`res/raw`), `file://`, and debug (`http://`) all load.
