### PR TITLE
fix(ios): zero-initialize TfLiteCoreMlDelegateOptions

### DIFF
--- a/cpp/TfliteHelpers.cpp
+++ b/cpp/TfliteHelpers.cpp
@@ -133,7 +133,15 @@ int getTensorTotalLength(const TfLiteTensor* tensor) {
 TfLiteDelegate* getCoreMLDelegate() {
 #ifdef __APPLE__
 #if FAST_TFLITE_ENABLE_CORE_ML
-  TfLiteCoreMlDelegateOptions delegateOptions;
+  // MUST be zero-initialized: TfLiteCoreMlDelegateOptions is a plain C struct
+  // and there is no ...OptionsDefault() helper. Without `= {}` the fields
+  // (enabled_devices, coreml_version, max_delegated_partitions,
+  // min_nodes_per_partition) are stack garbage that poisons the delegate's
+  // graph partitioning — EXC_BAD_ACCESS inside the first
+  // TfLiteInterpreterInvoke on device/OS combos whose stack layout produces
+  // harmful values. Zero values are the documented defaults (ANE-only
+  // devices, newest CoreML version, unlimited partitions).
+  TfLiteCoreMlDelegateOptions delegateOptions = {};
   TfLiteDelegate* coreMlDelegate = TfLiteCoreMlDelegateCreate(&delegateOptions);
   return coreMlDelegate;
 #else // FAST_TFLITE_ENABLE_CORE_ML

--- a/cpp/TfliteHelpers.cpp
+++ b/cpp/TfliteHelpers.cpp
@@ -133,14 +133,6 @@ int getTensorTotalLength(const TfLiteTensor* tensor) {
 TfLiteDelegate* getCoreMLDelegate() {
 #ifdef __APPLE__
 #if FAST_TFLITE_ENABLE_CORE_ML
-  // MUST be zero-initialized: TfLiteCoreMlDelegateOptions is a plain C struct
-  // and there is no ...OptionsDefault() helper. Without `= {}` the fields
-  // (enabled_devices, coreml_version, max_delegated_partitions,
-  // min_nodes_per_partition) are stack garbage that poisons the delegate's
-  // graph partitioning — EXC_BAD_ACCESS inside the first
-  // TfLiteInterpreterInvoke on device/OS combos whose stack layout produces
-  // harmful values. Zero values are the documented defaults (ANE-only
-  // devices, newest CoreML version, unlimited partitions).
   TfLiteCoreMlDelegateOptions delegateOptions = {};
   TfLiteDelegate* coreMlDelegate = TfLiteCoreMlDelegateCreate(&delegateOptions);
   return coreMlDelegate;


### PR DESCRIPTION
## What

`getCoreMLDelegate()` declares `TfLiteCoreMlDelegateOptions delegateOptions;` without initialization. It's a plain C struct with no `...OptionsDefault()` helper, so all four fields (`enabled_devices`, `coreml_version`, `max_delegated_partitions`, `min_nodes_per_partition`) are indeterminate stack garbage.

Depending on what happens to be on the stack, this poisons the delegate's graph partitioning — we've seen it produce `EXC_BAD_ACCESS` inside the first `TfLiteInterpreterInvoke` on some device/OS combinations, and it can also silently change which devices the delegate enables.

## Fix

`= {}`. Zero values are the [documented defaults](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/delegates/coreml/coreml_delegate.h) (ANE-only devices, newest CoreML version, unlimited partitions).

## History

This is the same bug #165 fixed — that PR was closed because it targeted the pre-Nitro `TensorflowPlugin.cpp` and you invited a re-roll against the current codebase ("if this is still relevant in the latest version, we can open another PR and get it merged 👍"). It is still relevant: the Nitro migration carried the uninitialized declaration into `cpp/TfliteHelpers.cpp`.

We've been shipping this as a patch-package fix in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)