### PR TITLE
fix: skip unavailable delegates and free delegates on model destruction

### DIFF
--- a/cpp/HybridTfliteModel.cpp
+++ b/cpp/HybridTfliteModel.cpp
@@ -17,9 +17,10 @@ namespace margelo::nitro::tflite {
 
 HybridTfliteModel::HybridTfliteModel(TfLiteInterpreter* interpreter,
                                      std::shared_ptr<ArrayBuffer> modelData,
-                                     std::vector<TensorflowModelDelegate> delegates)
+                                     std::vector<TensorflowModelDelegate> delegates,
+                                     std::vector<std::function<void()>> delegateDeleters)
     : HybridObject(TAG), _interpreter(interpreter), _delegates(std::move(delegates)),
-      _modelData(modelData) {
+      _modelData(modelData), _delegateDeleters(std::move(delegateDeleters)) {
   TfLiteStatus status = TfLiteInterpreterAllocateTensors(_interpreter);
   if (status != kTfLiteOk) {
     throw std::runtime_error(
@@ -33,6 +34,11 @@ HybridTfliteModel::~HybridTfliteModel() {
     TfLiteInterpreterDelete(_interpreter);
     _interpreter = nullptr;
   }
+  // Delegates must outlive the interpreter — delete them second.
+  for (auto& deleter : _delegateDeleters) {
+    deleter();
+  }
+  _delegateDeleters.clear();
   // _modelData (shared_ptr<ArrayBuffer>) is automatically freed
 }
 

--- a/cpp/HybridTfliteModel.hpp
+++ b/cpp/HybridTfliteModel.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 #include "HybridTfliteModelSpec.hpp"
+#include <functional>
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #if defined(ANDROID)
 #include <tflite/c/c_api.h>
@@ -18,7 +20,8 @@ namespace margelo::nitro::tflite {
 class HybridTfliteModel : public HybridTfliteModelSpec {
 public:
   explicit HybridTfliteModel(TfLiteInterpreter* interpreter, std::shared_ptr<ArrayBuffer> modelData,
-                             std::vector<TensorflowModelDelegate> delegates);
+                             std::vector<TensorflowModelDelegate> delegates,
+                             std::vector<std::function<void()>> delegateDeleters);
   ~HybridTfliteModel();
 
   // Properties (from HybridTfliteModelSpec)
@@ -42,6 +45,10 @@ private:
   TfLiteInterpreter* _interpreter = nullptr;
   std::vector<TensorflowModelDelegate> _delegates;
   std::shared_ptr<ArrayBuffer> _modelData;
+  // Free the TFLite delegates (GPU/CoreML/NNAPI) — the interpreter does not
+  // own them, so without these every model destruction leaks the delegate's
+  // compiled kernels / driver contexts.
+  std::vector<std::function<void()>> _delegateDeleters;
   std::unordered_map<std::string, std::shared_ptr<ArrayBuffer>> _outputBuffers;
 };
 

--- a/cpp/HybridTfliteModule.cpp
+++ b/cpp/HybridTfliteModule.cpp
@@ -1,15 +1,49 @@
 #include "HybridTfliteModule.hpp"
 #include "TfliteHelpers.hpp"
 
+#include <functional>
+#include <utility>
+#include <vector>
+
 #if defined(ANDROID)
 #include <tflite/c/c_api.h>
+#include <tflite/delegates/gpu/delegate.h>
+#include <tflite/delegates/nnapi/nnapi_delegate_c_api.h>
 #elif defined(__APPLE__)
 #include <TensorFlowLiteC/TensorFlowLiteC.h>
+#if FAST_TFLITE_ENABLE_CORE_ML
+#include <TensorFlowLiteCCoreML/TensorFlowLiteCCoreML.h>
+#endif
 #else
 #error "Invalid Platform!"
 #endif
 
 namespace margelo::nitro::tflite {
+
+/**
+ * TFLite's C API does not transfer delegate ownership to the interpreter —
+ * the caller must keep the delegate alive and free it itself (after the
+ * interpreter has been deleted). Returns nullptr for delegate types without
+ * a public delete function.
+ */
+static std::function<void()> makeDelegateDeleter(TensorflowModelDelegate delegateType,
+                                                 TfLiteDelegate* delegate) {
+  switch (delegateType) {
+#if defined(__APPLE__) && FAST_TFLITE_ENABLE_CORE_ML
+    case TensorflowModelDelegate::CORE_ML:
+      return [delegate]() { TfLiteCoreMlDelegateDelete(delegate); };
+#endif
+#if defined(ANDROID)
+    case TensorflowModelDelegate::ANDROID_GPU:
+      return [delegate]() { TfLiteGpuDelegateV2Delete(delegate); };
+    case TensorflowModelDelegate::NNAPI:
+      return [delegate]() { TfLiteNnapiDelegateDelete(delegate); };
+#endif
+    default:
+      // METAL never produces a delegate; unknown types were rejected earlier.
+      return nullptr;
+  }
+}
 
 /**
  * Return a Hardware accelerated delegate, or throws
@@ -43,9 +77,21 @@ HybridTfliteModule::createModel(const std::shared_ptr<ArrayBuffer>& modelData,
 
   // Add all hardware accelerated delegates (e.g. GPU, NPU, ...)
   // if any. The default CPU delegate will always be available.
+  std::vector<TensorflowModelDelegate> effectiveDelegates;
+  std::vector<std::function<void()>> delegateDeleters;
+  effectiveDelegates.reserve(delegates.size());
   for (const TensorflowModelDelegate& delegateType : delegates) {
     TfLiteDelegate* delegate = getDelegate(delegateType);
+    if (delegate == nullptr) {
+      // e.g. CoreML on devices without a Neural Engine — fall back to CPU
+      // instead of registering a null delegate with the interpreter.
+      continue;
+    }
     TfLiteInterpreterOptionsAddDelegate(options, delegate);
+    effectiveDelegates.push_back(delegateType);
+    if (auto deleter = makeDelegateDeleter(delegateType, delegate)) {
+      delegateDeleters.push_back(std::move(deleter));
+    }
   }
 
   TfLiteInterpreter* interpreter = TfLiteInterpreterCreate(model, options);
@@ -57,11 +103,15 @@ HybridTfliteModule::createModel(const std::shared_ptr<ArrayBuffer>& modelData,
   TfLiteModelDelete(model);
 
   if (interpreter == nullptr) {
+    for (auto& deleter : delegateDeleters) {
+      deleter();
+    }
     throw std::runtime_error("Failed to create TFLite interpreter!");
   }
 
   // Wrap in HybridTfliteModel — stores shared_ptr<ArrayBuffer> to keep model data bytes alive
-  return std::make_shared<HybridTfliteModel>(interpreter, modelData, delegates);
+  return std::make_shared<HybridTfliteModel>(interpreter, modelData, effectiveDelegates,
+                                             std::move(delegateDeleters));
 }
 
 } // namespace margelo::nitro::tflite


### PR DESCRIPTION
## What

Two related delegate-lifecycle bugs in `createModel` / `HybridTfliteModel`:

### 1. Null delegates are registered with the interpreter

Delegate factories can legitimately return `nullptr` — e.g. `TfLiteCoreMlDelegateCreate` on devices without a Neural Engine (the default `enabled_devices` is ANE-only). `createModel` passed that `nullptr` straight into `TfLiteInterpreterOptionsAddDelegate`, corrupting/crashing interpreter creation.

**Fix:** skip null delegates so the model falls back to CPU. `getDelegates()` now also reports only the delegates that were *actually* registered, instead of claiming a delegate is active when its creation returned null.

### 2. Delegates are never freed

TFLite's C API does **not** transfer delegate ownership to the interpreter — the caller must keep the delegate alive and delete it itself after the interpreter is destroyed ([TFLite docs](https://ai.google.dev/edge/api/tflite/c/group/c-api)). `~HybridTfliteModel` deleted the interpreter but never the delegates, so every model destruction leaked the delegate's compiled kernels / driver contexts. For the GPU delegate that's a substantial native+driver allocation per model load — very visible in apps that load/unload models across their lifecycle.

**Fix:** capture a per-delegate deleter (`TfLiteGpuDelegateV2Delete` / `TfLiteNnapiDelegateDelete` / `TfLiteCoreMlDelegateDelete`) at creation time and run them in the destructor *after* `TfLiteInterpreterDelete` (delegates must outlive the interpreter), plus on the interpreter-creation failure path.

## Testing

Running in production (React Native scanner app, Android GPU delegate + CoreML) as a patch-package fix — model load/release cycles no longer accumulate native memory, verified with heapprofd before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)