### PR TITLE
feat: implement dispose() for deterministic native resource release

### DIFF
--- a/cpp/HybridTfliteModel.cpp
+++ b/cpp/HybridTfliteModel.cpp
@@ -17,9 +17,10 @@ namespace margelo::nitro::tflite {
 
 HybridTfliteModel::HybridTfliteModel(TfLiteInterpreter* interpreter,
                                      std::shared_ptr<ArrayBuffer> modelData,
-                                     std::vector<TensorflowModelDelegate> delegates)
+                                     std::vector<TensorflowModelDelegate> delegates,
+                                     std::vector<std::function<void()>> delegateDeleters)
     : HybridObject(TAG), _interpreter(interpreter), _delegates(std::move(delegates)),
-      _modelData(modelData) {
+      _modelData(modelData), _delegateDeleters(std::move(delegateDeleters)) {
   TfLiteStatus status = TfLiteInterpreterAllocateTensors(_interpreter);
   if (status != kTfLiteOk) {
     throw std::runtime_error(
@@ -33,6 +34,11 @@ HybridTfliteModel::~HybridTfliteModel() {
     TfLiteInterpreterDelete(_interpreter);
     _interpreter = nullptr;
   }
+  // Delegates must outlive the interpreter — delete them second.
+  for (auto& deleter : _delegateDeleters) {
+    deleter();
+  }
+  _delegateDeleters.clear();
   // _modelData (shared_ptr<ArrayBuffer>) is automatically freed
 }
 

--- a/cpp/HybridTfliteModel.cpp
+++ b/cpp/HybridTfliteModel.cpp
@@ -23,6 +23,7 @@ HybridTfliteModel::HybridTfliteModel(TfLiteInterpreter* interpreter,
       _modelData(modelData), _delegateDeleters(std::move(delegateDeleters)) {
   TfLiteStatus status = TfLiteInterpreterAllocateTensors(_interpreter);
   if (status != kTfLiteOk) {
+    releaseNativeResources();
     throw std::runtime_error(
         "TFLite: Failed to allocate memory for input/output tensors! Status: " +
         tfLiteStatusToString(status));
@@ -30,6 +31,13 @@ HybridTfliteModel::HybridTfliteModel(TfLiteInterpreter* interpreter,
 }
 
 HybridTfliteModel::~HybridTfliteModel() {
+  // No lock: the destructor only runs once the last shared_ptr dropped, so no
+  // other thread can be inside a method. If dispose() already ran, all
+  // pointers are null and this is a no-op.
+  releaseNativeResources();
+}
+
+void HybridTfliteModel::releaseNativeResources() {
   if (_interpreter != nullptr) {
     TfLiteInterpreterDelete(_interpreter);
     _interpreter = nullptr;
@@ -39,7 +47,21 @@ HybridTfliteModel::~HybridTfliteModel() {
     deleter();
   }
   _delegateDeleters.clear();
-  // _modelData (shared_ptr<ArrayBuffer>) is automatically freed
+  // Model bytes must outlive the interpreter — drop our reference last.
+  // (JS-side references to output buffers keep their own shared_ptrs alive.)
+  _modelData = nullptr;
+  _outputBuffers.clear();
+}
+
+void HybridTfliteModel::dispose() {
+  // The lock waits out an in-flight inference on another thread — freeing
+  // the interpreter under a running TfLiteInterpreterInvoke would be a
+  // native crash.
+  std::lock_guard<std::mutex> lock(_lifecycleMutex);
+  if (_disposed.exchange(true, std::memory_order_acq_rel)) {
+    return;
+  }
+  releaseNativeResources();
 }
 
 std::vector<TensorflowModelDelegate> HybridTfliteModel::getDelegates() {
@@ -47,6 +69,8 @@ std::vector<TensorflowModelDelegate> HybridTfliteModel::getDelegates() {
 }
 
 std::vector<Tensor> HybridTfliteModel::getInputs() {
+  std::lock_guard<std::mutex> lock(_lifecycleMutex);
+  throwIfDisposed();
   int count = TfLiteInterpreterGetInputTensorCount(_interpreter);
   std::vector<Tensor> tensors;
   tensors.reserve(count);
@@ -69,6 +93,8 @@ std::vector<Tensor> HybridTfliteModel::getInputs() {
 }
 
 std::vector<Tensor> HybridTfliteModel::getOutputs() {
+  std::lock_guard<std::mutex> lock(_lifecycleMutex);
+  throwIfDisposed();
   int count = TfLiteInterpreterGetOutputTensorCount(_interpreter);
   std::vector<Tensor> tensors;
   tensors.reserve(count);
@@ -152,6 +178,10 @@ void HybridTfliteModel::invoke() {
 
 std::vector<std::shared_ptr<ArrayBuffer>>
 HybridTfliteModel::runSync(const std::vector<std::shared_ptr<ArrayBuffer>>& input) {
+  // Held for the whole inference so dispose() can never free the interpreter
+  // mid-invoke. The disposed-throw is a catchable JS error on any runtime.
+  std::lock_guard<std::mutex> lock(_lifecycleMutex);
+  throwIfDisposed();
   copyInputBuffers(input);
   invoke();
   return copyOutputBuffers();
@@ -159,12 +189,20 @@ HybridTfliteModel::runSync(const std::vector<std::shared_ptr<ArrayBuffer>>& inpu
 
 std::shared_ptr<Promise<std::vector<std::shared_ptr<ArrayBuffer>>>>
 HybridTfliteModel::run(const std::vector<std::shared_ptr<ArrayBuffer>>& input) {
-  // Copy input buffers on caller (JS) thread first — input ArrayBuffers are
-  // non-owning JS buffers that may be GC'd if we access them async.
-  copyInputBuffers(input);
+  {
+    // Copy input buffers on caller (JS) thread first — input ArrayBuffers are
+    // non-owning JS buffers that may be GC'd if we access them async.
+    std::lock_guard<std::mutex> lock(_lifecycleMutex);
+    throwIfDisposed();
+    copyInputBuffers(input);
+  }
   std::shared_ptr<HybridTfliteModel> sharedThis = shared_cast<HybridTfliteModel>();
   return Promise<std::vector<std::shared_ptr<ArrayBuffer>>>::async(
       [sharedThis]() -> std::vector<std::shared_ptr<ArrayBuffer>> {
+        // Re-acquire on the async thread: dispose() may have landed between
+        // the input copy above and this lambda running.
+        std::lock_guard<std::mutex> lock(sharedThis->_lifecycleMutex);
+        sharedThis->throwIfDisposed();
         sharedThis->invoke();
         return sharedThis->copyOutputBuffers();
       });

--- a/cpp/HybridTfliteModel.hpp
+++ b/cpp/HybridTfliteModel.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 #include "HybridTfliteModelSpec.hpp"
+#include <functional>
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #if defined(ANDROID)
 #include <tflite/c/c_api.h>
@@ -18,7 +20,8 @@ namespace margelo::nitro::tflite {
 class HybridTfliteModel : public HybridTfliteModelSpec {
 public:
   explicit HybridTfliteModel(TfLiteInterpreter* interpreter, std::shared_ptr<ArrayBuffer> modelData,
-                             std::vector<TensorflowModelDelegate> delegates);
+                             std::vector<TensorflowModelDelegate> delegates,
+                             std::vector<std::function<void()>> delegateDeleters);
   ~HybridTfliteModel();
 
   // Properties (from HybridTfliteModelSpec)
@@ -42,6 +45,10 @@ private:
   TfLiteInterpreter* _interpreter = nullptr;
   std::vector<TensorflowModelDelegate> _delegates;
   std::shared_ptr<ArrayBuffer> _modelData;
+  // Free the TFLite delegates (GPU/CoreML/NNAPI) — the interpreter does not
+  // own them, so without these every model destruction leaks the delegate's
+  // compiled kernels / driver contexts.
+  std::vector<std::function<void()>> _delegateDeleters;
   std::unordered_map<std::string, std::shared_ptr<ArrayBuffer>> _outputBuffers;
 };
 

--- a/cpp/HybridTfliteModel.hpp
+++ b/cpp/HybridTfliteModel.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
 #include "HybridTfliteModelSpec.hpp"
+#include <atomic>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -24,6 +26,17 @@ public:
                              std::vector<std::function<void()>> delegateDeleters);
   ~HybridTfliteModel();
 
+  /**
+   * Deterministically free the interpreter, delegates, and model buffer NOW,
+   * without waiting for every runtime's GC to drop its reference (worklet
+   * runtimes may not GC for a long time, especially while backgrounded).
+   * Thread-safe: blocks until an in-flight inference on another thread
+   * completes. All subsequent runSync/run/getInputs/getOutputs calls throw a
+   * catchable JS error. Idempotent. Called by Nitro when JS invokes
+   * `model.dispose()`.
+   */
+  void dispose() override;
+
   // Properties (from HybridTfliteModelSpec)
   std::vector<TensorflowModelDelegate> getDelegates() override;
   std::vector<Tensor> getInputs() override;
@@ -41,6 +54,20 @@ private:
   std::vector<std::shared_ptr<ArrayBuffer>> copyOutputBuffers();
   std::shared_ptr<ArrayBuffer> getOutputBufferForTensor(const TfLiteTensor* tensor);
 
+  // Shared by the destructor and dispose(); frees in the required order
+  // (interpreter -> delegates -> model buffer) and nulls the pointers so a
+  // second invocation is a no-op. Caller must hold _lifecycleMutex (except
+  // the destructor, which is only reachable single-threaded).
+  void releaseNativeResources();
+
+  // Caller must hold _lifecycleMutex. std::runtime_error is surfaced by
+  // Nitro as a catchable JS error on any runtime.
+  void throwIfDisposed() {
+    if (_disposed.load(std::memory_order_acquire)) {
+      throw std::runtime_error("TFLite: Model was disposed!");
+    }
+  }
+
 private:
   TfLiteInterpreter* _interpreter = nullptr;
   std::vector<TensorflowModelDelegate> _delegates;
@@ -50,6 +77,11 @@ private:
   // compiled kernels / driver contexts.
   std::vector<std::function<void()>> _delegateDeleters;
   std::unordered_map<std::string, std::shared_ptr<ArrayBuffer>> _outputBuffers;
+
+  // Serializes inference against dispose(). Uncontended in normal operation
+  // (one lock per inference, ~ns vs ~ms inference cost).
+  std::mutex _lifecycleMutex;
+  std::atomic<bool> _disposed{false};
 };
 
 } // namespace margelo::nitro::tflite

--- a/cpp/HybridTfliteModule.cpp
+++ b/cpp/HybridTfliteModule.cpp
@@ -1,15 +1,49 @@
 #include "HybridTfliteModule.hpp"
 #include "TfliteHelpers.hpp"
 
+#include <functional>
+#include <utility>
+#include <vector>
+
 #if defined(ANDROID)
 #include <tflite/c/c_api.h>
+#include <tflite/delegates/gpu/delegate.h>
+#include <tflite/delegates/nnapi/nnapi_delegate_c_api.h>
 #elif defined(__APPLE__)
 #include <TensorFlowLiteC/TensorFlowLiteC.h>
+#if FAST_TFLITE_ENABLE_CORE_ML
+#include <TensorFlowLiteCCoreML/TensorFlowLiteCCoreML.h>
+#endif
 #else
 #error "Invalid Platform!"
 #endif
 
 namespace margelo::nitro::tflite {
+
+/**
+ * TFLite's C API does not transfer delegate ownership to the interpreter —
+ * the caller must keep the delegate alive and free it itself (after the
+ * interpreter has been deleted). Returns nullptr for delegate types without
+ * a public delete function.
+ */
+static std::function<void()> makeDelegateDeleter(TensorflowModelDelegate delegateType,
+                                                 TfLiteDelegate* delegate) {
+  switch (delegateType) {
+#if defined(__APPLE__) && FAST_TFLITE_ENABLE_CORE_ML
+    case TensorflowModelDelegate::CORE_ML:
+      return [delegate]() { TfLiteCoreMlDelegateDelete(delegate); };
+#endif
+#if defined(ANDROID)
+    case TensorflowModelDelegate::ANDROID_GPU:
+      return [delegate]() { TfLiteGpuDelegateV2Delete(delegate); };
+    case TensorflowModelDelegate::NNAPI:
+      return [delegate]() { TfLiteNnapiDelegateDelete(delegate); };
+#endif
+    default:
+      // METAL never produces a delegate; unknown types were rejected earlier.
+      return nullptr;
+  }
+}
 
 /**
  * Return a Hardware accelerated delegate, or throws
@@ -43,9 +77,21 @@ HybridTfliteModule::createModel(const std::shared_ptr<ArrayBuffer>& modelData,
 
   // Add all hardware accelerated delegates (e.g. GPU, NPU, ...)
   // if any. The default CPU delegate will always be available.
+  std::vector<TensorflowModelDelegate> effectiveDelegates;
+  std::vector<std::function<void()>> delegateDeleters;
+  effectiveDelegates.reserve(delegates.size());
   for (const TensorflowModelDelegate& delegateType : delegates) {
     TfLiteDelegate* delegate = getDelegate(delegateType);
+    if (delegate == nullptr) {
+      // e.g. CoreML on devices without a Neural Engine — fall back to CPU
+      // instead of registering a null delegate with the interpreter.
+      continue;
+    }
     TfLiteInterpreterOptionsAddDelegate(options, delegate);
+    effectiveDelegates.push_back(delegateType);
+    if (auto deleter = makeDelegateDeleter(delegateType, delegate)) {
+      delegateDeleters.push_back(std::move(deleter));
+    }
   }
 
   TfLiteInterpreter* interpreter = TfLiteInterpreterCreate(model, options);
@@ -57,11 +103,15 @@ HybridTfliteModule::createModel(const std::shared_ptr<ArrayBuffer>& modelData,
   TfLiteModelDelete(model);
 
   if (interpreter == nullptr) {
+    for (auto& deleter : delegateDeleters) {
+      deleter();
+    }
     throw std::runtime_error("Failed to create TFLite interpreter!");
   }
 
   // Wrap in HybridTfliteModel — stores shared_ptr<ArrayBuffer> to keep model data bytes alive
-  return std::make_shared<HybridTfliteModel>(interpreter, modelData, delegates);
+  return std::make_shared<HybridTfliteModel>(interpreter, modelData, effectiveDelegates,
+                                             std::move(delegateDeleters));
 }
 
 } // namespace margelo::nitro::tflite


### PR DESCRIPTION
> **Note:** stacked on top of #197 (delegate lifecycle) — the first commit here is that PR. Review just the second commit, or merge #197 first and this rebases cleanly.

## What

`HybridTfliteModel` inherits Nitro's default **no-op** `dispose()`, so `model.dispose()` from JS frees nothing — the interpreter, delegates, and model buffer only go away when GC drops the last reference.

That's a real problem for frame-processor use: worklet runtimes may not GC for a long time (especially while the app is backgrounded), so large models + their GPU delegate contexts stay resident with no way to release them. In our app, releasing scanner models on background via a working `dispose()` frees ~86 MB of native/GPU memory that otherwise just sits there.

## Implementation

- **`dispose()`** frees interpreter → delegates → model buffer immediately, via a shared `releaseNativeResources()` that nulls pointers so destructor-after-dispose is a no-op. Idempotent.
- **Thread-safe:** a lifecycle mutex serializes `dispose()` against inference — `dispose()` blocks until an in-flight `TfLiteInterpreterInvoke` on another thread (frame processor) completes, since freeing the interpreter mid-invoke is a native crash. The mutex is uncontended in normal operation (one ~ns lock per ~ms inference).
- **`run()`** re-checks disposal on the async thread — `dispose()` can land between the caller-thread input copy and the async invoke.
- **Post-dispose calls** (`runSync`/`run`/`getInputs`/`getOutputs`) throw `TFLite: Model was disposed!` — a catchable JS error on any runtime, not a crash.
- Also releases resources on the `AllocateTensors` failure path in the constructor (previously leaked the interpreter+delegates when allocation failed).

## Testing

Running in production as a patch-package fix: models disposed on app background (with an active frame processor racing it), reloaded on foreground. No crashes across a soak test; post-dispose `runSync` calls surface as catchable JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)