### PR TITLE
fix(docs): the documented `'metal'` delegate throws unconditionally

### DIFF
--- a/MIGRATION_V2_TO_V3.md
+++ b/MIGRATION_V2_TO_V3.md
@@ -36,8 +36,22 @@ The `delegate` parameter has been renamed to `delegates` and now accepts an **ar
 ```
 
 ```diff
-- const model = useTensorflowModel(source, 'metal')
-+ const model = useTensorflowModel(source, ['metal'])
+- const model = useTensorflowModel(source, 'core-ml')
++ const model = useTensorflowModel(source, ['core-ml'])
+```
+
+### The `'metal'` delegate is not implemented
+
+`'metal'` is still part of the `TensorflowModelDelegate` union, but it has no
+implementation - creating a model with it throws
+`The Metal Delegate ("metal") is not implemented!`
+(see [`cpp/TfliteHelpers.cpp`](./cpp/TfliteHelpers.cpp), `getMetalDelegate()`).
+It is documented as deprecated on the `TensorflowModelDelegate` type. On Apple
+platforms, use `'core-ml'` instead:
+
+```diff
+- const model = useTensorflowModel(source, ['metal'])
++ const model = useTensorflowModel(source, ['core-ml'])
 ```
 
 ### The `'default'` delegate is removed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A high-performance [TensorFlow Lite](https://www.tensorflow.org/lite) library fo
 - 💨 Zero-copy ArrayBuffers
 - 🔧 Uses the low-level C/C++ TensorFlow Lite core API for direct memory access
 - 🔄 Supports swapping out TensorFlow Models at runtime
-- 🖥️ Supports GPU-accelerated delegates (CoreML/Metal/OpenGL)
+- 🖥️ Supports hardware-accelerated delegates (CoreML on iOS, GPU/NNAPI on Android)
 - 📸 Easy [VisionCamera](https://github.com/mrousavy/react-native-vision-camera) integration
 
 ## Migrating from v2

--- a/cpp/TfliteHelpers.cpp
+++ b/cpp/TfliteHelpers.cpp
@@ -147,7 +147,9 @@ TfLiteDelegate* getCoreMLDelegate() {
 }
 
 TfLiteDelegate* getMetalDelegate() {
-  throw std::runtime_error("Metal Delegate is not yet supported!");
+  throw std::runtime_error("The Metal Delegate (\"metal\") is not implemented! "
+                           "Use \"core-ml\" on Apple platforms, or \"android-gpu\"/\"nnapi\" on "
+                           "Android instead.");
 }
 
 TfLiteDelegate* getNNAPIDelegate() {

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -15,7 +15,6 @@ if linkage != nil
 end
 
 $EnableCoreMLDelegate=true
-$EnableMetalDelegate=true
 
 target 'TfliteExample' do
   config = use_native_modules!

--- a/src/loadTensorflowModel.ts
+++ b/src/loadTensorflowModel.ts
@@ -22,7 +22,7 @@ const tfliteModule =
  * * If you are passing in a `{ url: ... }`, make sure the URL points directly to a `.tflite` model. This can either be a web URL (`http://..`/`https://..`), or a local file (`file://..`).
  *
  * @param source The `.tflite` model in form of either a `require(..)` statement or a `{ url: string }`.
- * @param delegates The delegates to use for computations. Uses the standard CPU delegate per default. The `core-ml` or `metal` delegates are GPU-accelerated, but don't work on every model.
+ * @param delegates The delegates to use for computations. Pass an empty array (`[]`) to use the standard CPU delegate. The `core-ml` (iOS), `android-gpu` and `nnapi` (Android) delegates are hardware-accelerated, but don't work on every model.
  * @returns The loaded Model.
  */
 export async function loadTensorflowModel(

--- a/src/specs/Tflite.nitro.ts
+++ b/src/specs/Tflite.nitro.ts
@@ -1,5 +1,14 @@
 import type { HybridObject } from 'react-native-nitro-modules'
 
+/**
+ * A hardware-accelerating delegate to run the TFLite model with.
+ *
+ * - `'core-ml'`: CoreML (Apple platforms). Requires `$EnableCoreMLDelegate`.
+ * - `'nnapi'`: NNAPI (Android)
+ * - `'android-gpu'`: GPU (Android)
+ * - `'metal'`: **deprecated, not implemented** - creating a model with this
+ *   delegate always throws. Use `'core-ml'` on Apple platforms instead.
+ */
 export type TensorflowModelDelegate =
   | 'metal'
   | 'core-ml'

--- a/src/useTensorflowModel.ts
+++ b/src/useTensorflowModel.ts
@@ -24,7 +24,7 @@ export type TensorflowPlugin =
  * * If you are passing in a `{ url: ... }`, make sure the URL points directly to a `.tflite` model. This can either be a web URL (`http://..`/`https://..`), or a local file (`file://..`).
  *
  * @param source The `.tflite` model in form of either a `require(..)` statement or a `{ url: string }`.
- * @param delegates The delegates to use for computations. Uses the standard CPU delegate per default. The `core-ml` or `metal` delegates are GPU-accelerated, but don't work on every model.
+ * @param delegates The delegates to use for computations. Pass an empty array (`[]`) to use the standard CPU delegate. The `core-ml` (iOS), `android-gpu` and `nnapi` (Android) delegates are hardware-accelerated, but don't work on every model.
  * @returns The state of the Model.
  */
 export function useTensorflowModel(
@@ -50,7 +50,7 @@ export function useTensorflowModel(
     }
     load()
     // JSON.stringify compares delegates by value so inline array literals
-    // (e.g. ['core-ml', 'default']) don't cause the effect to re-run every render
+    // (e.g. ['core-ml']) don't cause the effect to re-run every render
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [source, JSON.stringify(delegates)])
 


### PR DESCRIPTION
## The contradiction

The v2 → v3 migration guide instructs users to migrate to the `'metal'` delegate:

https://github.com/mrousavy/react-native-fast-tflite/blob/691f4b8/MIGRATION_V2_TO_V3.md#L38-L41

```diff
- const model = useTensorflowModel(source, 'metal')
+ const model = useTensorflowModel(source, ['metal'])
```

That exact "after" snippet fails 100% of the time, on every platform. [`cpp/TfliteHelpers.cpp#L149-L151`](https://github.com/mrousavy/react-native-fast-tflite/blob/691f4b8/cpp/TfliteHelpers.cpp#L149-L151):

```cpp
TfLiteDelegate* getMetalDelegate() {
  throw std::runtime_error("Metal Delegate is not yet supported!");
}
```

There is no `#ifdef` and no build flag around it — unlike `getCoreMLDelegate()` (`#ifdef __APPLE__` / `#if FAST_TFLITE_ENABLE_CORE_ML`, [`TfliteHelpers.cpp#L133-L147`](https://github.com/mrousavy/react-native-fast-tflite/blob/691f4b8/cpp/TfliteHelpers.cpp#L133-L147)), `getNNAPIDelegate()` (`#ifdef ANDROID`) and `getAndroidGPUDelegate()` (`#ifdef ANDROID`). `getMetalDelegate()` is the only one whose body is a bare, unconditional `throw`.

The reachable path is unconditional too: `createModel` loops over every requested delegate and calls `getDelegate()`, which routes `METAL` straight there — [`HybridTfliteModule.cpp#L18-L31`](https://github.com/mrousavy/react-native-fast-tflite/blob/691f4b8/cpp/HybridTfliteModule.cpp#L18-L31) and [`#L46-L49`](https://github.com/mrousavy/react-native-fast-tflite/blob/691f4b8/cpp/HybridTfliteModule.cpp#L46-L49). So the throw happens during model creation, before the interpreter is built.

Three more places repeat the claim:

- [`README.md#L15`](https://github.com/mrousavy/react-native-fast-tflite/blob/691f4b8/README.md?plain=1#L15) — "Supports GPU-accelerated delegates (CoreML/**Metal**/OpenGL)". The `### Using GPU Delegates` section below it only documents CoreML and Android GPU/NNAPI, so the feature bullet is the only place Metal is promised.
- [`example/ios/Podfile#L18`](https://github.com/mrousavy/react-native-fast-tflite/blob/691f4b8/example/ios/Podfile#L18) — `$EnableMetalDelegate=true`. The podspec never reads that global; it reads only `$EnableCoreMLDelegate` and only defines `FAST_TFLITE_ENABLE_CORE_ML` ([`react-native-fast-tflite.podspec#L5-L9`](https://github.com/mrousavy/react-native-fast-tflite/blob/691f4b8/react-native-fast-tflite.podspec#L5-L9), [`#L29-L31`](https://github.com/mrousavy/react-native-fast-tflite/blob/691f4b8/react-native-fast-tflite.podspec#L29-L31)). Setting it does nothing — it reads as "this is the switch that turns Metal on", which is the most misleading part of the whole story.
- [`src/specs/Tflite.nitro.ts#L4`](https://github.com/mrousavy/react-native-fast-tflite/blob/691f4b8/src/specs/Tflite.nitro.ts#L4) — `'metal'` is an undocumented member of the public `TensorflowModelDelegate` union, so autocomplete offers it as an equal peer of `'core-ml'`.

## What this PR changes

Documentation and one error message. No behaviour change, no type-level breaking change.

| File | Change |
|---|---|
| `README.md` | Feature bullet now names the delegates that have an implementation |
| `MIGRATION_V2_TO_V3.md` | Array-migration example uses `'core-ml'`; new short section documents that `'metal'` is not implemented |
| `src/specs/Tflite.nitro.ts` | JSDoc on `TensorflowModelDelegate` documenting each member, and that `'metal'` is deprecated / not implemented |
| `cpp/TfliteHelpers.cpp` | Error message names the delegates that actually work |
| `example/ios/Podfile` | Removes the no-op `$EnableMetalDelegate=true` |

### Three stale doc comments fixed in passing

`delegates` became a **required** positional parameter, but both doc comments still described it as optional with a default:

- [`src/loadTensorflowModel.ts#L25`](https://github.com/mrousavy/react-native-fast-tflite/blob/691f4b8/src/loadTensorflowModel.ts#L25) and [`src/useTensorflowModel.ts#L27`](https://github.com/mrousavy/react-native-fast-tflite/blob/691f4b8/src/useTensorflowModel.ts#L27): *"Uses the standard CPU delegate per default"* — there is no default; you must pass `[]`. (#182 fixed the README examples but not these.) They also pointed users at `metal` as a GPU-accelerated option.
- [`src/useTensorflowModel.ts#L53`](https://github.com/mrousavy/react-native-fast-tflite/blob/691f4b8/src/useTensorflowModel.ts#L53): the comment example `['core-ml', 'default']` references `'default'`, which the same migration guide documents as removed and which no longer typechecks.

## Deprecate vs. remove `'metal'`

**I deprecated it in place rather than removing it from the union.** Happy to switch if you'd rather — the reasoning:

1. **Removing it is a breaking type change.** Anyone with `['metal']` in their source compiles today (it only throws at runtime). Removing the member turns that into a build error. Deciding whether that break is worth taking, and in which release, is your call — it doesn't belong in a docs-correctness PR.
2. **Removing it means regenerating nitrogen output and renumbering the enum.** `'metal'` is member `0` of the generated `TensorflowModelDelegate` enum ([`nitrogen/generated/shared/c++/TensorflowModelDelegate.hpp#L32-L35`](https://github.com/mrousavy/react-native-fast-tflite/blob/691f4b8/nitrogen/generated/shared/c%2B%2B/TensorflowModelDelegate.hpp#L32-L35)). Dropping it shifts `CORE_ML` 1→0, `NNAPI` 2→1, `ANDROID_GPU` 3→2 across the generated JSI converters, and requires deleting `getMetalDelegate()` from `cpp/TfliteHelpers.cpp` + `cpp/TfliteHelpers.hpp` and the `METAL` case from `cpp/HybridTfliteModule.cpp`.
3. **That larger diff would land on top of in-flight C++ work.** #196 edits `cpp/TfliteHelpers.cpp`; #197 and #198 edit `cpp/HybridTfliteModule.cpp`. As it stands this PR merges cleanly with all three (verified locally with a trial merge of #196, the only one sharing a file with this PR — clean).
4. The runtime already stops anyone who tries; this PR just makes the throw explain what to use instead.

**Honest caveat about the deprecation:** I first tried a per-member `/** @deprecated */` JSDoc directly on `| 'metal'`. I checked whether TypeScript actually surfaces it, and it does not — querying the TS 5.3.3 language service for completions at a `TensorflowModelDelegate` position returns `kindModifiers: ""` for every member, so there is no strikethrough on string-literal union members. (Prettier also collapses the union onto one line when a comment is inserted mid-union, which made the diff noisier for no gain.) So I moved the documentation to the type alias, where `getQuickInfoAtPosition` *does* return it — hovering `TensorflowModelDelegate` now shows the per-delegate list including the Metal warning. I'd rather say that plainly than imply a strikethrough that doesn't exist.

I have **not** claimed anywhere that Metal could or should be implemented — I only checked what the code does today, not what it would take to add.

## Verification

- `yarn typecheck` — passes
- `yarn lint` — passes
- `npx clang-format --dry-run -Werror cpp/TfliteHelpers.cpp` — clean (CI uses clang-format 16; checked with 17)
- `npx nitrogen` — regenerates `nitrogen/generated/**` byte-identically, confirming the JSDoc-only spec change does not affect generated native code
- Type-compat proof: compiled a file containing `const d: TensorflowModelDelegate = 'metal'`, `loadTensorflowModel(src, ['metal'])` and `useTensorflowModel(src, [d])` against this branch — 0 errors, so no existing user code breaks
- Trial-merged #196 (the only open PR touching a file this PR touches) — no conflict

`yarn test` currently fails on `main` for unrelated reasons (Babel/jest config), untouched here.
