### PR TITLE
fix(jest): repair the broken `yarn test` setup

### DIFF
--- a/.github/workflows/validate-js.yml
+++ b/.github/workflows/validate-js.yml
@@ -29,6 +29,35 @@ on:
       - 'example/*.tsx'
 
 jobs:
+  test:
+    name: Test JS (jest)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22
+
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+    - name: Restore node_modules from cache
+      uses: actions/cache@v4
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
+    - name: Install node_modules
+      run: yarn install --frozen-lockfile
+
+    - name: Run Jest
+      run: yarn test
+
   compile:
     name: Compile JS (tsc)
     runs-on: ubuntu-latest

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['module:@react-native/babel-preset'],
+}

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@expo/config-plugins": "^7.8.4",
     "@jamesacarr/eslint-formatter-github-actions": "^0.2.0",
     "@react-native-community/eslint-config": "^3.0.2",
+    "@react-native/babel-preset": "0.73.20",
     "@release-it/conventional-changelog": "^8.0.1",
     "@types/jest": "^29.5.11",
     "@types/react": "~18.2.48",
@@ -99,6 +100,10 @@
     "modulePathIgnorePatterns": [
       "<rootDir>/example/node_modules",
       "<rootDir>/lib/"
+    ],
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "<rootDir>/example/"
     ]
   },
   "release-it": {
@@ -125,11 +130,6 @@
     "tabWidth": 2,
     "trailingComma": "es5",
     "useTabs": false
-  },
-  "babel": {
-    "presets": [
-      "module:metro-react-native-babel-preset"
-    ]
   },
   "react-native-builder-bob": {
     "source": "src",

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,1 +1,0 @@
-it.todo('write a test')

--- a/src/__tests__/withAndroidGpuLibraries.test.ts
+++ b/src/__tests__/withAndroidGpuLibraries.test.ts
@@ -1,0 +1,135 @@
+import type {
+  AndroidConfig,
+  ExportedConfig,
+  ModProps,
+} from '@expo/config-plugins'
+import { withAndroidGpuLibraries } from '../expo-plugin/withAndroidGpuLibraries'
+
+type AndroidManifest = AndroidConfig.Manifest.AndroidManifest
+type ManifestUsesLibrary = AndroidConfig.Manifest.ManifestUsesLibrary
+type ManifestApplicationWithNativeLibraries =
+  AndroidConfig.Manifest.ManifestApplication & {
+    'uses-native-library'?: ManifestUsesLibrary[]
+  }
+
+function createExpoConfig(): ExportedConfig {
+  return { name: 'TfliteExample', slug: 'tflite-example' }
+}
+
+function createManifest(
+  usesNativeLibrary?: ManifestUsesLibrary[]
+): AndroidManifest {
+  const application: ManifestApplicationWithNativeLibraries = {
+    $: { 'android:name': '.MainApplication' },
+  }
+  if (usesNativeLibrary != null)
+    application['uses-native-library'] = usesNativeLibrary
+
+  return {
+    manifest: {
+      $: { 'xmlns:android': 'http://schemas.android.com/apk/res/android' },
+      queries: [],
+      application: [application],
+    },
+  }
+}
+
+/**
+ * Runs the `withAndroidGpuLibraries` plugin's `android.manifest` mod against the
+ * given manifest, the same way `expo prebuild` would, and returns the result.
+ */
+async function applyPlugin(
+  manifest: AndroidManifest,
+  enabledLibraries: boolean | string[]
+): Promise<AndroidManifest> {
+  const expoConfig = createExpoConfig()
+  const config = withAndroidGpuLibraries(
+    expoConfig,
+    enabledLibraries
+  ) as ExportedConfig
+  const mod = config.mods?.android?.manifest
+  if (mod == null)
+    throw new Error('withAndroidGpuLibraries did not register a manifest mod!')
+
+  const modRequest: ModProps<AndroidManifest> = {
+    projectRoot: '/app',
+    platformProjectRoot: '/app/android',
+    modName: 'manifest',
+    platform: 'android',
+    introspect: false,
+  }
+  const result = await mod({
+    ...config,
+    modResults: manifest,
+    modRequest: modRequest,
+    modRawConfig: expoConfig,
+  })
+
+  return result.modResults
+}
+
+function getUsesNativeLibraries(
+  manifest: AndroidManifest
+): ManifestUsesLibrary[] {
+  const application: ManifestApplicationWithNativeLibraries | undefined =
+    manifest.manifest.application?.[0]
+  if (application == null) throw new Error('No <application> in the manifest!')
+  return application['uses-native-library'] ?? []
+}
+
+function getUsesNativeLibraryNames(manifest: AndroidManifest): string[] {
+  return getUsesNativeLibraries(manifest).map((lib) => lib.$['android:name'])
+}
+
+describe('withAndroidGpuLibraries', () => {
+  it('adds libOpenCL.so when enabled with `true`', async () => {
+    const manifest = await applyPlugin(createManifest(), true)
+
+    expect(getUsesNativeLibraryNames(manifest)).toEqual(['libOpenCL.so'])
+  })
+
+  it('marks the added libraries as not required', async () => {
+    const manifest = await applyPlugin(createManifest(), true)
+
+    expect(getUsesNativeLibraries(manifest)[0]?.$).toEqual({
+      'android:name': 'libOpenCL.so',
+      'android:required': false,
+    })
+  })
+
+  it('adds libOpenCL.so alongside the explicitly listed libraries', async () => {
+    const manifest = await applyPlugin(createManifest(), [
+      'libOpenCL-pixel.so',
+      'libGLES_mali.so',
+    ])
+
+    expect(getUsesNativeLibraryNames(manifest)).toEqual([
+      'libOpenCL.so',
+      'libOpenCL-pixel.so',
+      'libGLES_mali.so',
+    ])
+  })
+
+  it('does not duplicate entries when prebuild runs twice', async () => {
+    const libraries = ['libOpenCL-pixel.so']
+    const once = await applyPlugin(createManifest(), libraries)
+    const twice = await applyPlugin(once, libraries)
+
+    expect(getUsesNativeLibraryNames(twice)).toEqual([
+      'libOpenCL.so',
+      'libOpenCL-pixel.so',
+    ])
+  })
+
+  it('keeps unrelated <uses-native-library> entries that are already present', async () => {
+    const existing: ManifestUsesLibrary = {
+      $: { 'android:name': 'libsomething-else.so', 'android:required': 'true' },
+    }
+    const manifest = await applyPlugin(createManifest([existing]), true)
+
+    expect(getUsesNativeLibraryNames(manifest)).toEqual([
+      'libsomething-else.so',
+      'libOpenCL.so',
+    ])
+  })
+})


### PR DESCRIPTION
`CONTRIBUTING.md` tells contributors to run `yarn test` ([lines 50-54](https://github.com/mrousavy/react-native-fast-tflite/blob/main/CONTRIBUTING.md#L50-L54)). On a fresh clone of `main`, it fails.

```
$ git clone https://github.com/mrousavy/react-native-fast-tflite.git
$ yarn install --frozen-lockfile
$ yarn test

FAIL src/__tests__/index.test.tsx
  ● Test suite failed to run

    Jest encountered an unexpected token
    ...
    SyntaxError: node_modules/@react-native/js-polyfills/error-guard.js: Missing semicolon. (14:4)

      12 | let _inGuard = 0;
      13 |
    > 14 | type ErrorHandler = (error: mixed, isFatal: boolean) => void;
         |     ^

Test Suites: 2 failed, 2 total
Tests:       0 total
```

After this PR:

```
$ yarn test

PASS src/__tests__/withAndroidGpuLibraries.test.ts
  withAndroidGpuLibraries
    ✓ adds libOpenCL.so when enabled with `true`
    ✓ marks the added libraries as not required
    ✓ adds libOpenCL.so alongside the explicitly listed libraries
    ✓ does not duplicate entries when prebuild runs twice
    ✓ keeps unrelated <uses-native-library> entries that are already present

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
```

## Root causes

**1. There is no *root* Babel config.**

`5aa0d16` ("chore: Clean up", 2023-08-22) deleted `babel.config.js` and moved its contents into a `babel` key in `package.json`:

```diff
 diff --git a/babel.config.js b/babel.config.js
 deleted file mode 100644
-module.exports = {
-  presets: ['module:metro-react-native-babel-preset'],
-};

 diff --git a/package.json b/package.json
+  "babel": {
+    "presets": [
+      "module:metro-react-native-babel-preset"
+    ]
+  },
```

Those two are not equivalent. A `babel` key in `package.json` is a **file-relative** config — Babel stops looking at the nearest `package.json`, so the root one never applies to files inside `node_modules/**` (each of those has its own `package.json`). Only a **root** config (`babel.config.js`) does. React Native's jest preset relies on Babel to strip Flow types out of RN internals, so with no root config that transform never runs, and `error-guard.js` blows up on `type ErrorHandler = ...`.

Separately, the preset that key names, `metro-react-native-babel-preset`, **is not installed at all** — it isn't in `package.json` and RN 0.73 no longer depends on it. So even for files it did apply to, it could not resolve.

A hint that the deletion was unintentional: `tsconfig.json` still lists `babel.config.js` in `include` to this day:

https://github.com/mrousavy/react-native-fast-tflite/blob/main/tsconfig.json#L24-L28

**2. The root runner collects the e2e harness test.**

`modulePathIgnorePatterns` only excludes `example/node_modules`, so `jest --listTests` at the root picked up:

```
src/__tests__/index.test.tsx
example/__tests__/tflite.harness.ts   ← belongs to example/jest.harness.config.mjs
```

That's the second failing suite — a `react-native-harness` test that the root jest runner has no business collecting.

**Why nobody noticed for three years:** `.github/workflows/validate-js.yml` runs only `tsc` and `eslint`. It has never run `yarn test`.

## Changes

- **`babel.config.js`** restored, using `@react-native/babel-preset`.
- **`@react-native/babel-preset` added as an explicit devDependency**, pinned to `0.73.20`. That exact version is already in `yarn.lock` as a transitive dependency of `react-native@0.73.3`, so **`yarn.lock` is unchanged and `yarn install --frozen-lockfile` still passes**.
- **Removed the `babel` key** from `package.json` — it was redundant once the root config exists, and it pointed at an uninstalled package.
- **`testPathIgnorePatterns`** added so the root runner leaves `example/` alone.
- **A real test suite** replacing `it.todo('write a test')` (see below).
- **A `test` job in `validate-js.yml`** so this can't silently rot again.

### On the choice of Babel preset

`metro-react-native-babel-preset` was deprecated in RN 0.73 in favour of `@react-native/babel-preset`, and the root's `react-native` devDependency is `0.73.3`. The rest of the repo already agrees — `example/babel.config.js` uses `module:@react-native/babel-preset`. So `@react-native/babel-preset` it is; `metro-react-native-babel-preset` would have to be newly added to `package.json` and `yarn.lock`, and would be the deprecated choice.

### On what to actually test

`src/` is mostly thin wrappers over Nitro hybrid objects, which need the native module. The Expo config plugin is the exception: `withAndroidGpuLibraries` is pure TypeScript operating on the parsed `AndroidManifest` object, so it can be tested properly. The suite covers what the [`enableAndroidGpuLibraries` docs](https://github.com/mrousavy/react-native-fast-tflite/blob/main/src/expo-plugin/%40types.ts#L7-L33) promise: `libOpenCL.so` is always added, listed libraries are appended, entries are `android:required="false"`, pre-existing unrelated `<uses-native-library>` entries survive, and re-running `expo prebuild` doesn't duplicate entries.

I checked these aren't vacuous by mutating the source and confirming they fail:

| Mutation to `withAndroidGpuLibraries.ts` | Result |
| --- | --- |
| remove the de-duplication branch (always `push`) | 1 failed |
| drop `libOpenCL.so` from the default list | 5 failed |
| flip `required: false` → `true` | 1 failed |

## Alternative: delete jest instead

Worth saying plainly — repairing this isn't obviously the right call. The real testing investment here is the `react-native-harness` e2e suite in `example/`, which runs on device and covers what actually matters for this library. If jest is vestigial to you, the smaller change is to delete the `test` script, the `jest` config block, the `jest`/`@types/jest` devDependencies and `src/__tests__/`, and drop the `yarn test` paragraph from `CONTRIBUTING.md`. That's a legitimate outcome and I'd be happy to send it instead.

I went the other way because the Expo plugin logic is genuinely unit-testable, is not covered by the harness suite (which never runs `expo prebuild`), and is the kind of code that breaks silently — a bad manifest merge shows up as a GPU delegate that quietly doesn't load. But it's your call.

## Verification

All from a clean clone with `rm -rf node_modules && yarn install --frozen-lockfile`:

- `yarn test` — 5 passed, 1 suite
- `yarn typecheck` — clean
- `yarn lint` — clean, and `git diff --exit-code HEAD` after `lint --fix` is clean (the CI gate)
- `jest --listTests` at the root now returns only `src/__tests__/withAndroidGpuLibraries.test.ts`
- `example/` untouched: `jest --config example/jest.harness.config.mjs --listTests` still resolves `example/__tests__/tflite.harness.ts`
- **Counterfactual:** removing `babel.config.js` reproduces the identical `SyntaxError ... error-guard.js: Missing semicolon. (14:4)`; restoring it goes back to green
- `yarn prepack` (`bob build`) still succeeds, and `lib/commonjs` + `lib/module` are **byte-identical** to a build from `main` — confirming the removed `package.json` `babel` key was never used by the build either

Not verified: I did not execute the `react-native-harness` suite itself, as it requires building and running the example app on a device. I only confirmed its config still resolves its test file, and `example/` has no changes in this PR.
